### PR TITLE
DIGISOS-1328: Legg digisos-test.com til allowed-origins i mock

### DIFF
--- a/src/main/resources/application-mock.yml
+++ b/src/main/resources/application-mock.yml
@@ -1,0 +1,7 @@
+cors:
+  allowed_origins:
+    - "https://digisos-test.com"
+    - "https://tjenester.nav.no/veivisersosialhjelp/"
+    - "https://tjenester-q0.nav.no/veivisersosialhjelp/"
+    - "https://tjenester-q1.nav.no/veivisersosialhjelp/"
+    - "https://tjenester-t1.nav.no/veivisersosialhjelp/"


### PR DESCRIPTION
Trodde vi hadde denne, men den lå kun i test, så ikke rart det feila.