### PR TITLE
Byttet context-path til /sosialhjelp

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -9,13 +9,13 @@ spec:
   image: docker.pkg.github.com/navikt/sosialhjelp-innsyn-api/sosialhjelp-innsyn-api:{{version}}
   port: 8080
   liveness:
-    path: /soknadsosialhjelp/innsyn-api/internal/isAlive
+    path: /sosialhjelp/innsyn-api/internal/isAlive
     initialDelay: 20
     timeout: 1
     periodSeconds: 5
     failureThreshold: 10
   readiness:
-    path: /soknadsosialhjelp/innsyn-api/internal/isReady
+    path: /sosialhjelp/innsyn-api/internal/isReady
     initialDelay: 20
     timeout: 1
   prometheus:

--- a/nais/dev/default.json
+++ b/nais/dev/default.json
@@ -1,7 +1,7 @@
 {
   "namespace": "default",
   "ingresses": [
-    "https://sosialhjelp-innsyn-api.nais.oera-q.local/soknadsosialhjelp/innsyn-api"
+    "https://sosialhjelp-innsyn-api.nais.oera-q.local/sosialhjelp/innsyn-api"
   ],
   "fiks_digisos_endpoint_url": "https://api.fiks.test.ks.no",
   "fiks_dokumentlager_endpoint_url": "https://minside.fiks.test.ks.no/",

--- a/nais/dev/q0.json
+++ b/nais/dev/q0.json
@@ -1,8 +1,7 @@
 {
   "namespace": "q0",
   "ingresses": [
-    "https://sosialhjelp-innsyn-api-q0.nais.oera-q.local/soknadsosialhjelp/innsyn-api",
-    "https://www-q0.nav.no/soknadsosialhjelp/innsyn-api",
+    "https://sosialhjelp-innsyn-api-q0.nais.oera-q.local/sosialhjelp/innsyn-api",
     "https://www-q0.nav.no/sosialhjelp/innsyn-api"
   ],
   "fiks_digisos_endpoint_url": "https://api.fiks.test.ks.no",

--- a/nais/dev/q1.json
+++ b/nais/dev/q1.json
@@ -1,8 +1,8 @@
 {
   "namespace": "q1",
   "ingresses": [
-    "https://sosialhjelp-innsyn-api-q1.nais.oera-q.local/soknadsosialhjelp/innsyn-api",
-    "https://www-q1.nav.no/soknadsosialhjelp/innsyn-api"
+    "https://sosialhjelp-innsyn-api-q1.nais.oera-q.local/sosialhjelp/innsyn-api",
+    "https://www-q1.nav.no/sosialhjelp/innsyn-api"
   ],
   "fiks_digisos_endpoint_url": "https://api.fiks.test.ks.no",
   "fiks_dokumentlager_endpoint_url": "https://minside.fiks.test.ks.no/",

--- a/nais/prod/default.json
+++ b/nais/prod/default.json
@@ -1,8 +1,8 @@
 {
   "namespace": "default",
   "ingresses": [
-    "https://sosialhjelp-innsyn-api.nais.oera.no/soknadsosialhjelp/innsyn-api",
-    "https://www.nav.no/soknadsosialhjelp/innsyn-api"
+    "https://sosialhjelp-innsyn-api.nais.oera.no/sosialhjelp/innsyn-api",
+    "https://www.nav.no/sosialhjelp/innsyn-api"
   ],
   "norg_endpoint_url": "https://api-gw.oera.no/norg2/api/v1/",
   "virksomhetssertifikat_vault_path": "/secret/virksomhetssertifikat/prod/sosialhjelp",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
 server:
   servlet:
-    context-path: '/soknadsosialhjelp/innsyn-api'
+    context-path: '/sosialhjelp/innsyn-api'
 
 client:
   fiks_digisos_endpoint_url: ${FIKS_DIGISOS_ENDPOINT_URL:fiks-digisos-url}
@@ -22,7 +22,7 @@ client:
 
 cors:
   allowed_origins:
-    - "https://tjenester.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-q0.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-q1.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-t1.nav.no/veivisersosialhjelp/"
+    - "https://www.nav.no/sosialhjelp/"
+    - "https://www-q0.nav.no/sosialhjelp/"
+    - "https://www-q1.nav.no/sosialhjelp/"
+    - "https://www-t1.nav.no/sosialhjelp/"

--- a/src/test/resources/application-mock.yml
+++ b/src/test/resources/application-mock.yml
@@ -1,12 +1,12 @@
 server:
   servlet:
-    context-path: '/soknadsosialhjelp/innsyn-api'
+    context-path: '/sosialhjelp/innsyn-api'
 
 cors:
   allowed_origins:
     - "http://localhost:3000"
     - "https://www.digisos-test.com"
-    - "https://tjenester.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-q0.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-q1.nav.no/veivisersosialhjelp/"
-    - "https://tjenester-t1.nav.no/veivisersosialhjelp/"
+    - "https://www.nav.no/sosialhjelp/"
+    - "https://www-q0.nav.no/sosialhjelp/"
+    - "https://www-q1.nav.no/sosialhjelp/"
+    - "https://www-t1.nav.no/sosialhjelp/"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,7 +6,7 @@ spring:
 
 server:
   servlet:
-    context-path: '/soknadsosialhjelp/innsyn-api'
+    context-path: '/sosialhjelp/innsyn-api'
 
 client:
   fiks_digisos_endpoint_url: 'http://localhost:51234'


### PR DESCRIPTION
- Byttet context-path fra /soknadsosialhjelp til /sosialhjelp
- Endret allowed-origins til å godta den nye sosialhjelp-veiviser og ikke den gamle slettede veivisersosialhjelp