### PR TITLE
Bygg Docker image på Jenkins

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,0 +1,12 @@
+FROM gradle:6.0.1-jdk11 as builder
+WORKDIR /source
+ADD / /source
+COPY gradle.properties $HOME/.gradle/
+RUN gradle test build
+RUN ls -l build/libs
+
+FROM navikt/java:11
+ENV LC_ALL="no_NB.UTF-8"
+ENV LANG="no_NB.UTF-8"
+ENV TZ="Europe/Oslo"
+COPY --from=builder /source/build/libs/sosialhjelp-innsyn-api-*.jar app.jar

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,7 +133,14 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
 }
 
+buildscript {
+    repositories {
+        maven("https://repo.adeo.no/repository/maven-central")
+    }
+}
+
 repositories {
+    maven("https://repo.adeo.no/repository/maven-central")
     mavenCentral()
     jcenter()
     maven("https://plugins.gradle.org/m2/")

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Denne filen må ha LF som line separator.
+
+# Stop scriptet om en kommando feiler
+set -e
+
+# Usage string
+usage="Script som bygger prosjektet og publiserer til nexus
+
+Om environment variabelen 'versjon' er satt vil den erstatte versjonen som ligger i pom.xml.
+
+Bruk:
+./$(basename "$0") OPTIONS
+
+Gyldige OPTIONS:
+    -h  | --help        - printer denne hjelpeteksten
+"
+
+# Default verdier
+PROJECT_ROOT="$( cd "$(dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Hent ut argumenter
+for arg in "$@"
+do
+case $arg in
+    -h|--help)
+    echo "$usage" >&2
+    exit 1
+    ;;
+    *) # ukjent argument
+    printf "Ukjent argument: %s\n" "$1" >&2
+    echo ""
+    echo "$usage" >&2
+    exit 1
+    ;;
+esac
+done
+
+function go_to_project_root() {
+    cd ${PROJECT_ROOT}
+}
+
+function export_version() {
+    GIT_COMMIT_HASH=$(git log -n 1 --pretty=format:'%h')
+    GIT_COMMIT_DATE=$(git log -1 --pretty='%ad' --date=format:'%Y%m%d.%H%M')
+    export versjon="1.0_${GIT_COMMIT_DATE}_${GIT_COMMIT_HASH}"
+}
+
+function docker_login() {
+    echo ${REPO_PASSWORD} | docker login -u ${REPO_USERNAME} --password-stdin repo.adeo.no:5443
+}
+
+function build_and_deploy_docker() {
+    docker build . -t repo.adeo.no:5443/sosialhjelp-innsyn-api:${versjon} -f Dockerfile.jenkins
+    docker push repo.adeo.no:5443/sosialhjelp-innsyn-api:${versjon}
+}
+
+
+go_to_project_root
+export_version
+docker_login
+build_and_deploy_docker

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,6 @@
+systemProp.http.proxyHost=webproxy-utvikler.nav.no
+systemProp.http.proxyPort=8088
+systemProp.http.nonProxyHosts=localhost|127.0.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*devel
+systemProp.https.proxyHost=webproxy-utvikler.nav.no
+systemProp.https.proxyPort=8088
+systemProp.https.nonProxyHosts=localhost|127.0.0.1|*.local|*.adeo.no|*.nav.no|*.aetat.no|*.devillo.no|*.oera.no|*devel


### PR DESCRIPTION
Fallback-løsning for å bygge Docker-image på Jenkins og pushe til `repo.adeo.no:5443/sosialhjelp-innsyn-api:{{version}}` når GitHub package registry ikke funker.