### PR TITLE
Fix/lukking av pdf 2

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/vedlegg/VedleggOpplastingService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/vedlegg/VedleggOpplastingService.kt
@@ -17,6 +17,7 @@ import no.nav.sbl.sosialhjelpinnsynapi.utils.isPdf
 import no.nav.sbl.sosialhjelpinnsynapi.utils.objectMapper
 import no.nav.sbl.sosialhjelpinnsynapi.virusscan.VirusScanner
 import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.encryption.InvalidPasswordException
 import org.springframework.stereotype.Component
 import org.springframework.web.multipart.MultipartFile
 import java.io.IOException
@@ -140,6 +141,9 @@ class VedleggOpplastingService(private val fiksClient: FiksClient,
                         }
                         return "OK"
                     }
+        } catch (e: InvalidPasswordException) {
+            log.warn(MESSAGE_PDF_IS_ENCRYPTED, e)
+            return MESSAGE_PDF_IS_ENCRYPTED
         } catch (e: IOException) {
             log.warn(MESSAGE_COULD_NOT_LOAD_DOCUMENT, e)
             return MESSAGE_COULD_NOT_LOAD_DOCUMENT


### PR DESCRIPTION
nytt forsøk på lukking av pdf ved å bruke kotlins `use`-funksjon.

Ved passord-beskyttede pdf'er gir vi PDF_IS_ENCRYPTED istedet for COULD_NOT_LOAD_DOCUMENT