### PR TITLE
Lukke ettersendelsePdf sin document etter den er lagret i byteArray.

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/pdf/PdfGenerator.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/pdf/PdfGenerator.kt
@@ -30,6 +30,7 @@ class PdfGenerator internal constructor() {
         val baos = ByteArrayOutputStream()
         currentStream.close()
         document.save(baos)
+        document.close()
         return baos.toByteArray()
     }
 


### PR DESCRIPTION
Da pdfbox klager med Warning: You did not close a PDF Document.