### PR TITLE
Øker minne for podder i nais

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -48,10 +48,10 @@ spec:
   resources:
     limits:
       cpu: 500m
-      memory: 1Gi
+      memory: 2Gi
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 1Gi
   env:
 {{#each env}}
     - name: {{@key}}


### PR DESCRIPTION
Det ser ut til at innsyn-api innimellom går tom for minne i JVM. Dette gjelder spesielt for opplasting av vedlegg som mellomlagres  i minne under opplasting. Øker i første omgang minnet som er tilgjengelig for hver pod. Hvis det ikke hjelper kan vi tweake på parametere for JVM.