### PR TITLE
Feature/digisos 1678 klargjore cors for call

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/CORSFilter.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/CORSFilter.kt
@@ -23,7 +23,7 @@ class CORSFilter : Filter {
 
         if (!isRunningInProd() || ALLOWED_ORIGINS.contains(origin)) {
             httpResponse.setHeader("Access-Control-Allow-Origin", origin)
-            httpResponse.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, X-XSRF-TOKEN, Authorization, NAV-Call-Id")
+            httpResponse.setHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Accept, X-XSRF-TOKEN, Authorization, Nav-Call-Id")
             httpResponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
             httpResponse.setHeader("Access-Control-Allow-Credentials", "true")
         }


### PR DESCRIPTION
Klargjør CORSFilter så det kan ta imot en ny header NAV-Call-Id fra frontend som skal sendes og logges i alle applikasjonene i digisos tjenesten. 