### PR TITLE
Legger til Nav-Call-Id også i spring security sin cors-sjekk.

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/ApiConfig.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/ApiConfig.kt
@@ -43,7 +43,7 @@ class WebSecurityConfig : WebSecurityConfigurerAdapter() {
                 "https://digisos.labs.nais.io",
                 "https://www.digisos-test.com")
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE")
-        configuration.allowedHeaders = listOf("Origin", "Content-Type", "Accept", "Authorization")
+        configuration.allowedHeaders = listOf("Origin", "Content-Type", "Accept", "Authorization", "Nav-Call-Id")
         configuration.allowCredentials = true
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", configuration)


### PR DESCRIPTION
Siden prod og q-miljø har backend og frontend på samme domene, skal ikke denne buggen være der.
Den er kun mulig å oppdage ved lokal kjøring med profile mock.