### PR TITLE
Whiteliste localhost:3002 i Spring security.

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/ApiConfig.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/config/ApiConfig.kt
@@ -40,6 +40,7 @@ class WebSecurityConfig : WebSecurityConfigurerAdapter() {
                 "https://sosialhjelp-innsyn.labs.nais.io",
                 "http://localhost:3000",
                 "http://localhost:3001",
+                "http://localhost:3002",
                 "https://digisos.labs.nais.io",
                 "https://www.digisos-test.com")
         configuration.allowedMethods = listOf("GET", "POST", "PUT", "DELETE")


### PR DESCRIPTION
Da portnummer på frontend er/vil bli endret til dette.