### PR TITLE
utvide cache-levetid i dev-sbs

### DIFF
--- a/nais/dev/q0.json
+++ b/nais/dev/q0.json
@@ -24,7 +24,7 @@
     "ID_PORTEN_SCOPE": "ks:fiks",
     "AZUREAD_DISCOVERYURL": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",
     "AZUREAD_CLIENTID": "0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5",
-    "CACHE_TIME_TO_LIVE_SECONDS": "10",
+    "CACHE_TIME_TO_LIVE_SECONDS": "30",
     "REDIS_HOST": "sosialhjelp-innsyn-api-redis.default.svc.nais.local",
     "VILKAR_ENABLED": "true",
     "DOKUMENTASJONKRAV_ENABLED": "true",

--- a/nais/dev/q1.json
+++ b/nais/dev/q1.json
@@ -24,7 +24,7 @@
     "ID_PORTEN_SCOPE": "ks:fiks",
     "AZUREAD_DISCOVERYURL": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",
     "AZUREAD_CLIENTID": "0090b6e1-ffcc-4c37-bc21-049f7d1f0fe5",
-    "CACHE_TIME_TO_LIVE_SECONDS": "10",
+    "CACHE_TIME_TO_LIVE_SECONDS": "30",
     "REDIS_HOST": "sosialhjelp-innsyn-api-redis.default.svc.nais.local",
     "VILKAR_ENABLED": "true",
     "DOKUMENTASJONKRAV_ENABLED": "true",


### PR DESCRIPTION
Forhåpentligvis kan evt problemer mot redis (eller kode redisService kaller) avdekkes lettere ved testing med litt lengre levetid på cache