### PR TITLE
Teste å fjerne ORG_GRADLE_PROJECT-vars

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,5 +12,3 @@ jobs:
           args: --org=teamdigisos
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          ORG_GRADLE_PROJECT_githubUser: x-access-token
-          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tester å fjerne dette da det er det eneste som skiller innsyn-api fra login-api. Og håper at dette er grunnen til at innsyn-api ikke dukker opp i snyk.