### PR TITLE
Tester å overstyre snyk navn og gruppe

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/gradle-jdk11@master
         with:
-          args: --org=teamdigisos --project-name='sosialhjelp-innsyn-api' --remote-repo-url='sosialhjelp-innsyn-api'
+          args: --org=teamdigisos --project-name=sosialhjelp-innsyn-api --remote-repo-url=sosialhjelp-innsyn-api
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           ORG_GRADLE_PROJECT_githubUser: x-access-token	


### PR DESCRIPTION
For å se om den da klarer å forstå at vi har ignorert sårbarheter via snyk-nettsiden
Edit: Det ser ut som dette fungerer 🎉 

Kilde: https://support.snyk.io/hc/en-us/articles/360003022397-Is-it-possible-to-rename-projects-in-the-Snyk-