### PR TITLE
Caching av NavEnhet fra Norg

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/redis/RedisService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/redis/RedisService.kt
@@ -14,8 +14,10 @@ import java.io.IOException
 @Component
 class RedisService(
         private val redisStore: RedisStore,
-        private val cacheProperties: CacheProperties
+        cacheProperties: CacheProperties
 ) {
+
+    private val defaultTimeToLiveSeconds = cacheProperties.timeToLiveSeconds
 
     fun get(key: String, requestedClass: Class<out Any>): Any? {
         val get: ByteArray? = redisStore.get(key) // Redis har konfigurert timout for disse.
@@ -37,8 +39,8 @@ class RedisService(
         }
     }
 
-    fun put(key: String, value: ByteArray) {
-        val set = redisStore.set(key, value, cacheProperties.timeToLiveSeconds)
+    fun put(key: String, value: ByteArray, timeToLiveSeconds: Long = defaultTimeToLiveSeconds) {
+        val set = redisStore.set(key, value, timeToLiveSeconds)
         if (set == null) {
             log.warn("Cache put feilet eller fikk timeout")
         } else if (set == "OK") {

--- a/src/test/kotlin/no/nav/sbl/sosialhjelpinnsynapi/client/norg/NorgClientImplTest.kt
+++ b/src/test/kotlin/no/nav/sbl/sosialhjelpinnsynapi/client/norg/NorgClientImplTest.kt
@@ -1,0 +1,72 @@
+package no.nav.sbl.sosialhjelpinnsynapi.client.norg
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.sbl.sosialhjelpinnsynapi.config.ClientProperties
+import no.nav.sbl.sosialhjelpinnsynapi.domain.NavEnhet
+import no.nav.sbl.sosialhjelpinnsynapi.redis.RedisService
+import no.nav.sbl.sosialhjelpinnsynapi.responses.ok_navenhet
+import no.nav.sbl.sosialhjelpinnsynapi.utils.objectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+
+internal class NorgClientImplTest {
+
+    private val clientProperties: ClientProperties = mockk(relaxed = true)
+    private val restTemplate: RestTemplate = mockk()
+    private val redisService: RedisService = mockk()
+    private val norgClient = NorgClientImpl(clientProperties, restTemplate, redisService)
+
+    private val enhetsnr = "8888"
+
+    @BeforeEach
+    fun init() {
+        clearAllMocks()
+
+        every { redisService.get(any(), any()) } returns null
+        every { redisService.put(any(), any(), any()) } just Runs
+    }
+
+    @Test
+    fun `skal hente fra cache`() {
+        val navEnhet = objectMapper.readValue<NavEnhet>(ok_navenhet)
+        every { redisService.get(any(), NavEnhet::class.java) } returns navEnhet
+
+        val result2 = norgClient.hentNavEnhet(enhetsnr)
+
+        assertThat(result2).isNotNull
+
+        verify(exactly = 1) { redisService.get(any(), any()) }
+        verify(exactly = 0) { redisService.put(any(), any(), any()) }
+    }
+
+    @Test
+    fun `skal hente fra Norg og lagre til cache hvis cache er tom`() {
+        val mockResponse: ResponseEntity<String> = mockk()
+        every { mockResponse.body } returns ok_navenhet
+        every { redisService.get(any(), NavEnhet::class.java) } returns null
+        every {
+            restTemplate.exchange(
+                    any(),
+                    any(),
+                    any(),
+                    String::class.java,
+                    enhetsnr)
+        } returns mockResponse
+
+        val result2 = norgClient.hentNavEnhet(enhetsnr)
+
+        assertThat(result2).isNotNull
+
+        verify(exactly = 1) { redisService.get(any(), any()) }
+        verify(exactly = 1) { redisService.put(any(), any(), any()) }
+    }
+}

--- a/src/test/kotlin/no/nav/sbl/sosialhjelpinnsynapi/responses/NorgResponses.kt
+++ b/src/test/kotlin/no/nav/sbl/sosialhjelpinnsynapi/responses/NorgResponses.kt
@@ -1,0 +1,23 @@
+package no.nav.sbl.sosialhjelpinnsynapi.responses
+
+val ok_navenhet = """
+    {
+      "enhetId": 100000000,
+      "navn": "NAV Eiganes og Tasta",
+      "enhetNr": "8888",
+      "antallRessurser": 1,
+      "status": "Aktiv",
+      "orgNivaa": "EN",
+      "type": "LOKAL",
+      "organisasjonsnummer": "999999999",
+      "underEtableringDato": "1970-01-01",
+      "aktiveringsdato": "1970-01-01",
+      "underAvviklingDato": null,
+      "nedleggelsesdato": null,
+      "oppgavebehandler": true,
+      "versjon": 25,
+      "sosialeTjenester": null,
+      "kanalstrategi": "kanalstrategi",
+      "orgNrTilKommunaltNavKontor": "11111111"
+    }
+""".trimIndent()


### PR DESCRIPTION
Legger til støtte for å kunne lagre NavEnhet-responser fra Norg til Redis-cachen. 
Satte bare default levetid på 1 time for NavEnheter - men dette kan jo endres.