### PR TITLE
Fjerner cat av docker tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,5 +57,4 @@ jobs:
         run: docker build -t ${{ env.DOCKER_TAG }} .
       - name: Push docker image
         run: |
-          cat DOCKER_TAG
           docker push ${{ env.DOCKER_TAG }}


### PR DESCRIPTION
Brakk bygget pga skrivefeil, men infoen outputes uansett i workflowen i `docker push`