### PR TITLE
Logge vedtaksBrevId og sted

### DIFF
--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/client/fiks/FiksClientImpl.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/client/fiks/FiksClientImpl.kt
@@ -112,7 +112,7 @@ class FiksClientImpl(
                     String::class.java,
                     vars)
 
-            log.info("Hentet dokument (${requestedClass.simpleName}) fra Fiks, dokumentlagerId=$dokumentlagerId")
+            log.debug("Hentet dokument (${requestedClass.simpleName}) fra Fiks, dokumentlagerId=$dokumentlagerId")
             return objectMapper.readValue(response.body!!, requestedClass)
                     .also { lagreTilCache(dokumentlagerId, it) }
         } catch (e: HttpClientErrorException) {

--- a/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/service/saksstatus/SaksStatusService.kt
+++ b/src/main/kotlin/no/nav/sbl/sosialhjelpinnsynapi/service/saksstatus/SaksStatusService.kt
@@ -37,6 +37,7 @@ class SaksStatusService(
         val vedtakfilUrlList = when {
             sak.vedtak.isEmpty() -> null
             else -> sak.vedtak.map {
+                log.info("Hentet url til vedtaksfil: ${it.vedtaksFilUrl}")
                 VedtaksfilUrl(it.dato, it.vedtaksFilUrl)
             }
         }


### PR DESCRIPTION
* Legger på info-logg med vedtaksurlen. Da det er nyttig å vite referansen og hvordan filen er sendt, for å finne ut av hvorfor vi får tilbakemeldinger på at brukere ikke kan åpne vedtaksbrev. Lenken inneholder ikke personinformasjon

* Endrer logg-nivå til debug for hentet dokument, da vi ikke har hatt behov for denne, og de generer mye logger.