### PR TITLE
Fjern restconfig

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/MultipartConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/MultipartConfig.kt
@@ -1,0 +1,19 @@
+package no.nav.sosialhjelp.innsyn.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.multipart.commons.CommonsMultipartResolver
+
+private const val MAX_UPLOAD_SIZE = 350 * 1024 * 1024L //350 MB. Summen av filer som kan sendes i et POST-kall
+
+@Configuration
+class MulitpartConfig {
+
+    @Bean(name = ["multipartResolver"])
+    fun multipartResolver(): CommonsMultipartResolver {
+        val multipartResolver = CommonsMultipartResolver()
+        multipartResolver.setMaxUploadSize(MAX_UPLOAD_SIZE)
+        return multipartResolver
+    }
+
+}


### PR DESCRIPTION
Ble tidligere brukt av resttemplate for deserialisering av json-responser