### PR TITLE
Bruke hendelsereferansen fra søknaden

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/SoknadDokumentasjonskrav.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/SoknadDokumentasjonskrav.kt
@@ -18,7 +18,7 @@ fun InternalDigisosSoker.applySoknadKrav(fiksDigisosId: String, originalSoknadNA
                     it.type,
                     it.tilleggsinfo,
                     JsonVedlegg.HendelseType.SOKNAD,
-                    null,
+                    it.hendelseReferanse,
                     null,
                     unixToLocalDateTime(timestampSendt),
                     false) }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggService.kt
@@ -1,6 +1,7 @@
 package no.nav.sosialhjelp.innsyn.service.vedlegg
 
 import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonFiler
+import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonVedlegg
 import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonVedleggSpesifikasjon
 import no.nav.sosialhjelp.api.fiks.DokumentInfo
 import no.nav.sosialhjelp.api.fiks.EttersendtInfoNAV
@@ -45,6 +46,8 @@ class VedleggService(
                     InternalVedlegg(
                             vedlegg.type,
                             vedlegg.tilleggsinfo,
+                            vedlegg.hendelseType,
+                            vedlegg.hendelseReferanse,
                             matchDokumentInfoAndJsonFiler(originalSoknadNAV.vedlegg, vedlegg.filer),
                             unixToLocalDateTime(originalSoknadNAV.timestampSendt)
                     )
@@ -81,6 +84,8 @@ class VedleggService(
                                 InternalVedlegg(
                                         vedlegg.type,
                                         vedlegg.tilleggsinfo,
+                                        vedlegg.hendelseType,
+                                        vedlegg.hendelseReferanse,
                                         dokumentInfoList,
                                         unixToLocalDateTime(ettersendelse.timestampSendt)
                                 )
@@ -114,6 +119,8 @@ class VedleggService(
 data class InternalVedlegg(
         val type: String,
         val tilleggsinfo: String?,
+        val hendelseType: JsonVedlegg.HendelseType?,
+        val hendelseReferanse: String?,
         val dokumentInfoList: List<DokumentInfo>,
         val tidspunktLastetOpp: LocalDateTime
 )

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonEtterspurtTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonEtterspurtTest.kt
@@ -6,6 +6,7 @@ import io.mockk.mockk
 import no.finn.unleash.Unleash
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
+import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonVedlegg
 import no.nav.sosialhjelp.api.fiks.DigisosSak
 import no.nav.sosialhjelp.innsyn.client.norg.NorgClient
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
@@ -152,7 +153,7 @@ internal class DokumentasjonEtterspurtTest {
                                 SOKNADS_STATUS_UNDERBEHANDLING.withHendelsestidspunkt(tidspunkt_2)
                         ))
         every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
-                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
+                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, null, null, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
 
         val model = service.createModel(mockDigisosSak, "token")
 
@@ -175,6 +176,48 @@ internal class DokumentasjonEtterspurtTest {
     }
 
     @Test
+    fun `oppgaver som hentes fra soknad skal ha hendelseType og HendelseReferanse om de er satt i soknaden`() {
+        val hendelseReferanse = "1234"
+        every { innsynService.hentJsonDigisosSoker(any(), any(), any()) } returns null
+        every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
+                listOf(InternalVedlegg(
+                        vedleggKrevesDokumenttype,
+                        vedleggKrevesTilleggsinfo,
+                        JsonVedlegg.HendelseType.SOKNAD,
+                        hendelseReferanse,
+                        emptyList(),
+                        unixToLocalDateTime(tidspunkt_soknad)
+                ))
+
+        val model = service.createModel(mockDigisosSak, "token")
+
+        val oppgave = model.oppgaver.last()
+        assertThat(oppgave.tilleggsinfo).isEqualTo(vedleggKrevesTilleggsinfo)
+        assertThat(oppgave.hendelsetype).isEqualTo(JsonVedlegg.HendelseType.SOKNAD)
+        assertThat(oppgave.hendelsereferanse).isEqualTo(hendelseReferanse)
+    }
+
+    @Test
+    fun `oppgaver som hentes fra soknad skal ha hendelseType men ikke hendelsereferanse om det ikke er satt i soknaden`() {
+        every { innsynService.hentJsonDigisosSoker(any(), any(), any()) } returns null
+        every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
+                listOf(InternalVedlegg(
+                        vedleggKrevesDokumenttype,
+                        vedleggKrevesTilleggsinfo,
+                        null,
+                        null,
+                        emptyList(),
+                        unixToLocalDateTime(tidspunkt_soknad)
+                ))
+
+        val model = service.createModel(mockDigisosSak, "token")
+
+        val oppgave = model.oppgaver.last()
+        assertThat(oppgave.hendelsetype).isEqualTo(JsonVedlegg.HendelseType.SOKNAD)
+        assertThat(oppgave.hendelsereferanse).isNull()
+    }
+
+    @Test
     internal fun `dokumentasjonEtterspurt overstyrer gjenstaende vedleggskrav fra soknad`() {
         every { innsynService.hentJsonDigisosSoker(any(), any(), any()) } returns
                 JsonDigisosSoker()
@@ -186,7 +229,7 @@ internal class DokumentasjonEtterspurtTest {
                                 DOKUMENTASJONETTERSPURT.withHendelsestidspunkt(tidspunkt_3)
                         ))
         every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
-                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
+                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, null, null, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
 
         val model = service.createModel(mockDigisosSak, "token")
 
@@ -216,7 +259,7 @@ internal class DokumentasjonEtterspurtTest {
                                 DOKUMENTASJONETTERSPURT_TOM_DOKUMENT_LISTE.withHendelsestidspunkt(tidspunkt_4)
                         ))
         every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
-                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
+                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, null, null, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
 
         val model = service.createModel(mockDigisosSak, "token")
 
@@ -244,7 +287,7 @@ internal class DokumentasjonEtterspurtTest {
                                 DOKUMENTASJONETTERSPURT_TOM_DOKUMENT_LISTE.withHendelsestidspunkt(tidspunkt_4)
                         ))
         every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
-                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
+                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, null, null, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
 
         val model = service.createModel(mockDigisosSak, "token")
 
@@ -271,7 +314,7 @@ internal class DokumentasjonEtterspurtTest {
                                 DOKUMENTASJONETTERSPURT_TOM_DOKUMENT_LISTE.withHendelsestidspunkt(tidspunkt_4)
                         ))
         every { vedleggService.hentSoknadVedleggMedStatus(VEDLEGG_KREVES_STATUS, any(), any(), any()) } returns
-                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
+                listOf(InternalVedlegg(vedleggKrevesDokumenttype, vedleggKrevesTilleggsinfo, null, null, emptyList(), unixToLocalDateTime(tidspunkt_soknad)))
 
         val model = service.createModel(mockDigisosSak, "token")
 

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/EventServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/EventServiceTest.kt
@@ -506,6 +506,8 @@ internal class EventServiceTest {
                 InternalVedlegg(
                         type = "statsborgerskap",
                         tilleggsinfo = "dokumentasjon",
+                        null,
+                        null,
                         dokumentInfoList = emptyList(),
                         tidspunktLastetOpp = LocalDateTime.now()
                 )
@@ -537,6 +539,8 @@ internal class EventServiceTest {
                 InternalVedlegg(
                         type = "statsborgerskap",
                         tilleggsinfo = "dokumentasjon",
+                        null,
+                        null,
                         dokumentInfoList = emptyList(),
                         tidspunktLastetOpp = LocalDateTime.now()
                 )

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/rest/VedleggControllerTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/rest/VedleggControllerTest.kt
@@ -68,6 +68,8 @@ internal class VedleggControllerTest {
                 InternalVedlegg(
                         dokumenttype,
                         tilleggsinfo,
+                        null,
+                        null,
                         listOf(DokumentInfo(filnavn, dokumentlagerId, 123L), DokumentInfo(filnavn2, dokumentlagerId2, 42L)),
                         LocalDateTime.now())
         )
@@ -96,10 +98,14 @@ internal class VedleggControllerTest {
                 InternalVedlegg(
                         dokumenttype,
                         null,
+                        null,
+                        null,
                         listOf(DokumentInfo(filnavn, dokumentlagerId, 123L)),
                         now),
                 InternalVedlegg(
                         dokumenttype,
+                        null,
+                        null,
                         null,
                         listOf(DokumentInfo(filnavn, dokumentlagerId, 123L)),
                         now)

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/hendelse/HendelseServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/hendelse/HendelseServiceTest.kt
@@ -107,8 +107,8 @@ internal class HendelseServiceTest {
     fun `Hendelse for opplastet vedlegg`() {
         every { eventService.createModel(any(), any()) } returns InternalDigisosSoker()
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(dokumenttype_1, null, listOf(dok1), tidspunkt4),
-                InternalVedlegg(dokumenttype_2, null, listOf(dok2, dok3), tidspunkt5))
+                InternalVedlegg(dokumenttype_1, null, null, null, listOf(dok1), tidspunkt4),
+                InternalVedlegg(dokumenttype_2, null, null, null, listOf(dok2, dok3), tidspunkt5))
 
         val hendelser = service.hentHendelser("123", "Token")
 
@@ -124,7 +124,7 @@ internal class HendelseServiceTest {
     fun `Hendelse for opplastet vedlegg - tom fil-liste skal ikke resultere i hendelse`() {
         every { eventService.createModel(any(), any()) } returns InternalDigisosSoker()
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(dokumenttype_2, null, emptyList(), tidspunkt5))
+                InternalVedlegg(dokumenttype_2, null, null, null, emptyList(), tidspunkt5))
 
         val hendelser = service.hentHendelser("123", "Token")
 
@@ -137,8 +137,8 @@ internal class HendelseServiceTest {
 
         every { eventService.createModel(any(), any()) } returns model
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(dokumenttype_1, null, listOf(dok1, dok2), tidspunkt4),
-                InternalVedlegg(dokumenttype_2, null, listOf(dok2, dok3), tidspunkt5))
+                InternalVedlegg(dokumenttype_1, null, null, null, listOf(dok1, dok2), tidspunkt4),
+                InternalVedlegg(dokumenttype_2, null, null, null, listOf(dok2, dok3), tidspunkt5))
 
         val hendelser = service.hentHendelser("123", "Token")
 
@@ -156,8 +156,8 @@ internal class HendelseServiceTest {
 
         every { eventService.createModel(any(), any()) } returns model
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(dokumenttype_1, null, listOf(dok1), tidspunkt4),
-                InternalVedlegg(dokumenttype_2, null, listOf(dok2), tidspunkt4))
+                InternalVedlegg(dokumenttype_1, null, null, null, listOf(dok1), tidspunkt4),
+                InternalVedlegg(dokumenttype_2, null, null, null, listOf(dok2), tidspunkt4))
 
         val hendelser = service.hentHendelser("123", "Token")
 
@@ -173,8 +173,8 @@ internal class HendelseServiceTest {
 
         every { eventService.createModel(any(), any()) } returns model
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(dokumenttype_1, null, listOf(dok1), tidspunkt4),
-                InternalVedlegg(dokumenttype_2, null, listOf(dok2), tidspunkt4.plus(1, ChronoUnit.MILLIS)))
+                InternalVedlegg(dokumenttype_1, null, null, null, listOf(dok1), tidspunkt4),
+                InternalVedlegg(dokumenttype_2, null, null, null, listOf(dok2), tidspunkt4.plus(1, ChronoUnit.MILLIS)))
 
         val hendelser = service.hentHendelser("123", "Token")
 

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/oppgave/OppgaveServiceTest.kt
@@ -150,10 +150,10 @@ internal class OppgaveServiceTest {
 
         every { eventService.createModel(any(), any()) } returns model
         every { vedleggService.hentEttersendteVedlegg(any(), any(), any()) } returns listOf(
-                InternalVedlegg(type, tillegg, emptyList(), tidspunktEtterKrav),
-                InternalVedlegg(type2, null, emptyList(), tidspunktEtterKrav),
-                InternalVedlegg(type3, tillegg3, emptyList(), tidspunktFoerKrav),
-                InternalVedlegg(type3, null, emptyList(), tidspunktEtterKrav))
+                InternalVedlegg(type, tillegg, null, null, emptyList(), tidspunktEtterKrav),
+                InternalVedlegg(type2, null, null, null, emptyList(), tidspunktEtterKrav),
+                InternalVedlegg(type3, tillegg3, null, null, emptyList(), tidspunktFoerKrav),
+                InternalVedlegg(type3, null, null, null, emptyList(), tidspunktEtterKrav))
 
         val responseList = service.hentOppgaver("123", token)
 


### PR DESCRIPTION
Bruke hendelsereferansen fra søknaden

NB: Men Lar hendelsetype:soknad fortsatt bli satt av innsyn. Dette betyr at alle ettersendelser etter aktivering av feature toggle vil få hendelsetype:soknad uavhengig av om søknaden sendte dette. 
(Hendelsereferanse vil kun bli lagt på når søknaden har sendt disse, altså for alle søknader som blir sendt inn etter feature toggle blir aktivert). Kjekt å vite i en overgangsperiode :) 