### PR TITLE
virusscan fix: add missing if-statement

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanClient.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanClient.kt
@@ -31,7 +31,7 @@ class VirusScanClient(
     override fun scan(filnavn: String?, data: ByteArray) {
         if (enabled && isInfected(filnavn, data)) {
             throw VirusScanException("Fant virus i fil forsøkt opplastet", null)
-        } else {
+        } else if (!enabled) {
             log.warn("Virusscanning er ikke aktivert")
         }
     }


### PR DESCRIPTION
Liten glipp her som gjør at vi logger at virusscan ikke er aktivert (selv om det er det)