### PR TITLE
Fjerner leading og ending whitespaces i filnavn

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
@@ -185,7 +185,7 @@ class VedleggOpplastingService(
         }
     }
 
-    private fun validateFilenameMatchInMetadataAndFiles(metadata: MutableList<OpplastetVedleggMetadata>, files: List<MultipartFile>) {
+    fun validateFilenameMatchInMetadataAndFiles(metadata: MutableList<OpplastetVedleggMetadata>, files: List<MultipartFile>) {
         val filnavnMetadata: List<String> = metadata.flatMap { it.filer.map { opplastetFil -> sanitizeFileName(opplastetFil.filnavn) } }
         val filnavnMultipart: List<String> = files.map { sanitizeFileName(it.originalFilename ?: "") }
         if (filnavnMetadata.size != filnavnMultipart.size) {

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggUtils.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggUtils.kt
@@ -15,7 +15,7 @@ fun getSha512FromByteArray(bytes: ByteArray?): String {
     return digest.fold("", { str, it -> str + "%02x".format(it) })
 }
 
-fun sanitizeFileName(filename: String) = Normalizer.normalize(filename, Normalizer.Form.NFC)
+fun sanitizeFileName(filename: String) = Normalizer.normalize(filename, Normalizer.Form.NFC).trim()
 
 fun detectTikaType(inputStream: InputStream): String {
     return Tika().detect(inputStream)

--- a/src/main/resources/application-mock.yml
+++ b/src/main/resources/application-mock.yml
@@ -7,7 +7,7 @@ management:
 innsyn:
   vedlegg:
     virusscan:
-      enabled: true
+      enabled: false
 
 client:
   fiks_digisos_endpoint_url: digisosapiurl


### PR DESCRIPTION
Fjerner leading og ending whitespaces i filnavn
Ref. denne loggen:
```
Filnavn som ga mismatch: 
FilnavnMetadata :  nr 3.jpg (9 tegn),
FilnavnMultipart: nr 3.jpg (8 tegn),
```

Disabler virusscan i profile mock igjen. Fordi profile mock er ment til å kjøre uten integrasjoner :)