### PR TITLE
Legger til INSTANCE resolver på HttpClient

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/norg/NorgConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/norg/NorgConfig.kt
@@ -1,11 +1,10 @@
 package no.nav.sosialhjelp.innsyn.client.norg
 
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
+import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
 
 @Configuration
 class NorgConfig(
@@ -16,6 +15,6 @@ class NorgConfig(
     fun norgWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
             .baseUrl(clientProperties.norgEndpointUrl)
-            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/pdl/PdlConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/pdl/PdlConfig.kt
@@ -2,6 +2,7 @@ package no.nav.sosialhjelp.innsyn.client.pdl
 
 import io.netty.channel.ChannelOption
 import io.netty.handler.timeout.ReadTimeoutHandler
+import io.netty.resolver.DefaultAddressResolverGroup
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
 import no.nav.sosialhjelp.innsyn.utils.IntegrationUtils
 import org.springframework.context.annotation.Bean
@@ -17,7 +18,7 @@ import reactor.netty.http.client.HttpClient
 @Configuration
 class PdlConfig(
     private val clientProperties: ClientProperties
-){
+) {
     @Bean
     fun pdlWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
@@ -27,6 +28,7 @@ class PdlConfig(
             .clientConnector(
                 ReactorClientHttpConnector(
                     HttpClient.newConnection()
+                        .resolver(DefaultAddressResolverGroup.INSTANCE)
                         .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 15000)
                         .doOnConnected { it.addHandlerLast(ReadTimeoutHandler(60)) }
                 )

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/sts/StsConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/sts/StsConfig.kt
@@ -2,12 +2,12 @@ package no.nav.sosialhjelp.innsyn.client.sts
 
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
 import no.nav.sosialhjelp.innsyn.utils.IntegrationUtils
+import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
 import java.util.Base64
@@ -25,7 +25,7 @@ class StsConfig (
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic ${credentials()}")
             .defaultHeader(IntegrationUtils.HEADER_NAV_APIKEY, System.getenv(STSTOKEN_APIKEY))
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 
     companion object {

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanConfig.kt
@@ -1,10 +1,9 @@
 package no.nav.sosialhjelp.innsyn.client.virusscan
 
+import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
 
 @Configuration
 class VirusScanConfig {
@@ -13,7 +12,7 @@ class VirusScanConfig {
     fun virusScanWebClient(webClientBuilder: WebClient.Builder) =
         webClientBuilder
             .baseUrl(DEFAULT_CLAM_URI)
-            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 
     companion object {

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/ProxiedWebClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/ProxiedWebClientConfig.kt
@@ -1,13 +1,12 @@
 package no.nav.sosialhjelp.innsyn.config
 
-import no.nav.sosialhjelp.innsyn.utils.getReactorClientHttpConnector
+import no.nav.sosialhjelp.innsyn.utils.getProxiedReactorClientHttpConnector
+import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
 
 @Profile("!(mock|mock-alt|local)")
 @Configuration
@@ -19,7 +18,7 @@ class ProxiedWebClientConfig {
     @Bean
     fun proxiedWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
-            .clientConnector(getReactorClientHttpConnector(proxyUrl))
+            .clientConnector(getProxiedReactorClientHttpConnector(proxyUrl))
             .build()
 
 }
@@ -31,7 +30,7 @@ class MockProxiedWebClientConfig {
     @Bean
     fun proxiedWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
-            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/WebClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/WebClientConfig.kt
@@ -1,10 +1,9 @@
 package no.nav.sosialhjelp.innsyn.config
 
+import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
-import reactor.netty.http.client.HttpClient
 
 @Configuration
 class WebClientConfig {
@@ -12,6 +11,6 @@ class WebClientConfig {
     @Bean
     fun webClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
-            .clientConnector(ReactorClientHttpConnector(HttpClient.newConnection()))
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/HttpClientUtil.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/HttpClientUtil.kt
@@ -1,17 +1,26 @@
 package no.nav.sosialhjelp.innsyn.utils
 
+import io.netty.resolver.DefaultAddressResolverGroup
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import reactor.netty.http.client.HttpClient
 import reactor.netty.transport.ProxyProvider
 import java.net.URL
 
-fun getReactorClientHttpConnector(proxyUrl: String): ReactorClientHttpConnector {
+fun getProxiedReactorClientHttpConnector(proxyUrl: String): ReactorClientHttpConnector {
     val uri = URL(proxyUrl)
 
     val httpClient: HttpClient = HttpClient.create()
+        .resolver(DefaultAddressResolverGroup.INSTANCE)
         .proxy { proxy ->
             proxy.type(ProxyProvider.Proxy.HTTP).host(uri.host).port(uri.port)
         }
 
+    return ReactorClientHttpConnector(httpClient)
+}
+
+fun getUnproxiedReactorClientHttpConnector(): ReactorClientHttpConnector {
+    val httpClient: HttpClient = HttpClient
+        .newConnection()
+        .resolver(DefaultAddressResolverGroup.INSTANCE)
     return ReactorClientHttpConnector(httpClient)
 }


### PR DESCRIPTION
```
HttpClient.resolver(DefaultAddressResolverGroup.INSTANCE)
```

Dette fordi vi får mange av disse loggene:
```
 Search domain query failed. Original hostname: 'api-gw.oera.no' failed to resolve 'api-gw.oera.no.teamdigisos.svc.nais.local'; nested exception is io.netty.resolver.dns.DnsResolveContext$SearchDomainUnknownHostException: Search domain query failed. Original hostname: 'api-gw.oera.no' failed to resolve 'api-gw.oera.no.teamdigisos.svc.nais.local'
```
Og det ser ut som dette kan være en løsning: https://github.com/reactor/reactor-netty/issues/1431

Stusser alikevel litt på hvorfor api-gw url-en bruker teamdigisos sin local srv url... Men greit å teste dette først