### PR TITLE
Setter json-smart versjon eksplisitt til 2.4.2.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,8 +28,6 @@ object Versions {
     const val fiksKryptering = "1.0.11"
     const val lettuce = "6.0.2.RELEASE"
     const val jempbox = "1.8.16"
-    const val jerseyMediaJaxb = "2.31"
-    const val bouncycastle = "1.67"
     const val unleash = "3.3.4"
     const val jsonSmart = "2.4.2"
 


### PR DESCRIPTION
(Pga 2.3 har sårbarhet fra snyk)
Dette er en avhengighet som blir dratt inn via nimbus, med de legger til en range av versjoner: [1.3.2,2.4.2]
 https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk/9.3.3

 Se token-support issue her: https://github.com/navikt/token-support/issues/276

 Fjerner to andre constraints som er oppfylt.