### PR TITLE
legger til `sistOppdatert` i response for DittNavOppgave.

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgave.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgave.kt
@@ -11,5 +11,7 @@ data class DittNavOppgave(
     val tekst: String,
     val link: String,
     val sikkerhetsnivaa: Int,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS")
+    val sistOppdatert: LocalDateTime,
     val aktiv: Boolean
 )

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgaverService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgaverService.kt
@@ -26,11 +26,11 @@ class DittNavOppgaverService(
 ) {
 
     fun hentAktiveOppgaver(token: String): List<DittNavOppgave> {
-        return hentOppgaver(token, true)
+        return hentOppgaver(token, aktive = true)
     }
 
     fun hentInaktiveOppgaver(token: String): List<DittNavOppgave> {
-        return hentOppgaver(token, false)
+        return hentOppgaver(token, aktive = false)
     }
 
     private fun hentOppgaver(token: String, aktive: Boolean): List<DittNavOppgave> {
@@ -72,6 +72,7 @@ class DittNavOppgaverService(
                     tekst = oppgavetekst(it.erFraInnsyn),
                     link = innsynlenke(digisosSak.fiksDigisosId),
                     sikkerhetsnivaa = SIKKERHETSNIVAA_3,
+                    sistOppdatert = toUtc(it.tidspunktForKrav),
                     aktiv = aktiv
                 )
             }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgaverServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/dittnav/DittNavOppgaverServiceTest.kt
@@ -110,6 +110,8 @@ internal class DittNavOppgaverServiceTest {
         assertThat(aktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(aktiveOppgaver[0].tekst).containsIgnoringCase("Vi mangler vedlegg")
         assertThat(aktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(aktiveOppgaver[0].sikkerhetsnivaa).isEqualTo(3)
+        assertThat(aktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(aktiveOppgaver[0].aktiv).isTrue
 
         assertThat(inaktiveOppgaver).isEmpty()
@@ -145,6 +147,7 @@ internal class DittNavOppgaverServiceTest {
         assertThat(inaktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(inaktiveOppgaver[0].tekst).containsIgnoringCase("Vi mangler vedlegg")
         assertThat(inaktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(inaktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(inaktiveOppgaver[0].aktiv).isFalse
     }
 
@@ -177,6 +180,7 @@ internal class DittNavOppgaverServiceTest {
         assertThat(aktiveOppgaver[0].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(aktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(aktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(aktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(aktiveOppgaver[0].aktiv).isTrue
 
         assertThat(inaktiveOppgaver).hasSize(1)
@@ -184,6 +188,7 @@ internal class DittNavOppgaverServiceTest {
         assertThat(inaktiveOppgaver[0].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(inaktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(inaktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(inaktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(inaktiveOppgaver[0].aktiv).isFalse
     }
 
@@ -223,11 +228,13 @@ internal class DittNavOppgaverServiceTest {
         assertThat(aktiveOppgaver[0].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(aktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(aktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(aktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(aktiveOppgaver[0].aktiv).isTrue
         assertThat(aktiveOppgaver[1].eventId).isEqualTo("oppgaveId2")
         assertThat(aktiveOppgaver[1].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav2))
         assertThat(aktiveOppgaver[1].grupperingsId).isEqualTo("behandlingsId2")
         assertThat(aktiveOppgaver[1].link).contains("sosialhjelp/innsyn/$digisosId2/status")
+        assertThat(aktiveOppgaver[1].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav2))
         assertThat(aktiveOppgaver[1].aktiv).isTrue
 
         assertThat(inaktiveOppgaver).isEmpty()
@@ -275,11 +282,13 @@ internal class DittNavOppgaverServiceTest {
         assertThat(inaktiveOppgaver[0].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(inaktiveOppgaver[0].grupperingsId).isEqualTo("behandlingsId")
         assertThat(inaktiveOppgaver[0].link).contains("sosialhjelp/innsyn/$digisosId/status")
+        assertThat(inaktiveOppgaver[0].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav))
         assertThat(inaktiveOppgaver[0].aktiv).isFalse
         assertThat(inaktiveOppgaver[1].eventId).isEqualTo("oppgaveId2")
         assertThat(inaktiveOppgaver[1].eventTidspunkt).isEqualTo(toUtc(tidspunktForKrav2))
         assertThat(inaktiveOppgaver[1].grupperingsId).isEqualTo("behandlingsId2")
         assertThat(inaktiveOppgaver[1].link).contains("sosialhjelp/innsyn/$digisosId2/status")
+        assertThat(inaktiveOppgaver[1].sistOppdatert).isEqualTo(toUtc(tidspunktForKrav2))
         assertThat(inaktiveOppgaver[1].aktiv).isFalse
     }
 }


### PR DESCRIPTION
Etter ønske fra DittNav. Eneste tidspunktet vi har å bruke er tidspunkt for hendelsen, så da brukes det for både `eventTidspunkt` og `sistOppdatert`