### PR TITLE
Bruk mimetype detektert av Tika, fremfor contenttype fra multipartfile.

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
@@ -57,7 +57,7 @@ class VedleggOpplastingService(
             val originalFilename = sanitizeFileName(file.originalFilename!!)
             val filename = createFilename(originalFilename, valideringer)
             renameFilenameInMetadataJson(originalFilename, filename, metadata)
-            filerForOpplasting.add(FilForOpplasting(filename, file.contentType, file.size, file.inputStream))
+            filerForOpplasting.add(FilForOpplasting(filename, detectTikaType(file.inputStream), file.size, file.inputStream))
         }
 
         // Generere pdf og legge til i listen over filer som skal krypteres og lastes opp


### PR DESCRIPTION
Siden vi kun godtar vedlegg som tika detekterer som `application/pdf`, `application/png` eller `application/jpeg` burde vi gjenbruke den detekterte mimetypen ved opplasting av vedlegg.

Tror dette skal løse utfordring fra FSL om "ukjent mimetype - application/octet-stream" har dukket opp i loggene.