### PR TITLE
mock-alt profile krever ikke VIRKSERT_STI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ group = "no.nav.sosialhjelp"
 object Versions {
     const val coroutines = "1.5.2"
     const val springBoot = "2.5.4"
-    const val sosialhjelpCommon = "1.f76ffa9"
+    const val sosialhjelpCommon = "1.00018ba"
     const val logback = "1.2.3"
     const val logstash = "6.6"
     const val filformat = "1.2021.08.27-10.29-41cf5ce1230a"

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/idporten/IdPortenClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/idporten/IdPortenClientConfig.kt
@@ -1,13 +1,20 @@
 package no.nav.sosialhjelp.innsyn.client.idporten
 
+import no.nav.sosialhjelp.idporten.client.AccessToken
+import no.nav.sosialhjelp.idporten.client.IdPortenAccessTokenResponse
 import no.nav.sosialhjelp.idporten.client.IdPortenClient
+import no.nav.sosialhjelp.idporten.client.IdPortenClientImpl
 import no.nav.sosialhjelp.idporten.client.IdPortenProperties
 import no.nav.sosialhjelp.innsyn.utils.getenv
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+import org.springframework.http.HttpHeaders
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
 
+@Profile("!mock-alt")
 @Configuration
 class IdPortenClientConfig(
     private val proxiedWebClient: WebClient,
@@ -19,7 +26,7 @@ class IdPortenClientConfig(
 
     @Bean
     fun idPortenClient(): IdPortenClient {
-        return IdPortenClient(
+        return IdPortenClientImpl(
             webClient = proxiedWebClient,
             idPortenProperties = idPortenProperties()
         )
@@ -33,5 +40,32 @@ class IdPortenClientConfig(
             configUrl = configUrl,
             virksomhetSertifikatPath = getenv("VIRKSERT_STI", "/var/run/secrets/nais.io/virksomhetssertifikat")
         )
+    }
+}
+
+@Profile("mock-alt")
+@Configuration
+class IdPortenClientConfigMockAlt(
+    private val proxiedWebClient: WebClient,
+    @Value("\${no.nav.sosialhjelp.idporten.token_url}") private val tokenUrl: String
+) {
+
+    @Bean
+    fun idPortenClient(): IdPortenClient {
+        return IdPortenClientMockAlt(proxiedWebClient, tokenUrl)
+    }
+
+    private class IdPortenClientMockAlt(
+        private val proxiedWebClient: WebClient,
+        private val tokenUrl: String
+    ) : IdPortenClient {
+
+        override suspend fun requestToken(attempts: Int, headers: HttpHeaders): AccessToken {
+            val response = proxiedWebClient.post()
+                .uri(tokenUrl)
+                .retrieve()
+                .awaitBody<IdPortenAccessTokenResponse>()
+            return AccessToken(response.accessToken, response.expiresIn)
+        }
     }
 }


### PR DESCRIPTION
Bump sosialhjelp-common. 
Legger til IdPortenClientMockAlt, som ikke krever at env variabelen VIRKSERT_STI er satt ved bruk av mock-alt profile