### PR TITLE
Bump spring kotlin. Fjerner appdynamics

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ group = "no.nav.sosialhjelp"
 
 object Versions {
     const val coroutines = "1.5.2"
-    const val springBoot = "2.6.0"
+    const val springBoot = "2.5.7"
     const val sosialhjelpCommon = "1.da234e2"
     const val logback = "1.2.7"
     const val logstash = "6.6"

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/dialog/DialogConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/dialog/DialogConfig.kt
@@ -19,8 +19,8 @@ class DialogConfig(
     private val clientProperties: ClientProperties,
 ) {
     @Bean
-    fun dialogWebClient(nonProxiedWebClientBuilder: WebClient.Builder): DialogWebClient {
-        val builder = nonProxiedWebClientBuilder
+    fun dialogWebClient(webClientBuilder: WebClient.Builder): DialogWebClient {
+        val builder = webClientBuilder
             .baseUrl(clientProperties.dialogEndpointUrl)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .clientConnector(

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/fiks/FiksConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/fiks/FiksConfig.kt
@@ -10,13 +10,13 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 class FiksConfig(
-    private val proxiedWebClientBuilder: WebClient.Builder,
+    private val proxiedWebClient: WebClient,
     private val clientProperties: ClientProperties,
 ) {
 
     @Bean
     fun fiksWebClient(): WebClient =
-        proxiedWebClientBuilder
+        proxiedWebClient.mutate()
             .baseUrl(clientProperties.fiksDigisosEndpointUrl)
             .codecs {
                 it.defaultCodecs().maxInMemorySize(16 * 1024 * 1024)

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/fiks/KommuneInfoClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/fiks/KommuneInfoClientConfig.kt
@@ -10,14 +10,14 @@ import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
 class KommuneInfoClientConfig(
-    private val proxiedWebClientBuilder: WebClient.Builder,
+    private val proxiedWebClient: WebClient,
     private val clientProperties: ClientProperties
 ) {
 
     @Bean
     fun kommuneInfoClient(): KommuneInfoClient {
         return KommuneInfoClientImpl(
-            proxiedWebClientBuilder.build(),
+            proxiedWebClient,
             fiksProperties()
         )
     }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/idporten/IdPortenClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/idporten/IdPortenClientConfig.kt
@@ -17,7 +17,7 @@ import org.springframework.web.reactive.function.client.awaitBody
 @Profile("!mock-alt")
 @Configuration
 class IdPortenClientConfig(
-    private val proxiedWebClientBuilder: WebClient.Builder,
+    private val proxiedWebClient: WebClient,
     @Value("\${no.nav.sosialhjelp.idporten.token_url}") private val tokenUrl: String,
     @Value("\${no.nav.sosialhjelp.idporten.client_id}") private val clientId: String,
     @Value("\${no.nav.sosialhjelp.idporten.scope}") private val scope: String,
@@ -27,7 +27,7 @@ class IdPortenClientConfig(
     @Bean
     fun idPortenClient(): IdPortenClient {
         return IdPortenClientImpl(
-            webClient = proxiedWebClientBuilder.build(),
+            webClient = proxiedWebClient,
             idPortenProperties = idPortenProperties()
         )
     }
@@ -46,13 +46,13 @@ class IdPortenClientConfig(
 @Profile("mock-alt")
 @Configuration
 class IdPortenClientConfigMockAlt(
-    private val proxiedWebClientBuilder: WebClient.Builder,
+    private val proxiedWebClient: WebClient,
     @Value("\${no.nav.sosialhjelp.idporten.token_url}") private val tokenUrl: String
 ) {
 
     @Bean
     fun idPortenClient(): IdPortenClient {
-        return IdPortenClientMockAlt(proxiedWebClientBuilder.build(), tokenUrl)
+        return IdPortenClientMockAlt(proxiedWebClient, tokenUrl)
     }
 
     private class IdPortenClientMockAlt(

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/norg/NorgConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/norg/NorgConfig.kt
@@ -1,6 +1,7 @@
 package no.nav.sosialhjelp.innsyn.client.norg
 
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
+import no.nav.sosialhjelp.innsyn.utils.HttpClientUtil.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
@@ -11,8 +12,9 @@ class NorgConfig(
 ) {
 
     @Bean
-    fun norgWebClient(nonProxiedWebClientBuilder: WebClient.Builder): WebClient =
-        nonProxiedWebClientBuilder
+    fun norgWebClient(webClientBuilder: WebClient.Builder): WebClient =
+        webClientBuilder
             .baseUrl(clientProperties.norgEndpointUrl)
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/pdl/PdlConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/pdl/PdlConfig.kt
@@ -18,8 +18,8 @@ class PdlConfig(
     private val clientProperties: ClientProperties
 ) {
     @Bean
-    fun pdlWebClient(nonProxiedWebClientBuilder: WebClient.Builder): WebClient =
-        nonProxiedWebClientBuilder
+    fun pdlWebClient(webClientBuilder: WebClient.Builder): WebClient =
+        webClientBuilder
             .baseUrl(clientProperties.pdlEndpointUrl)
             .defaultHeader(IntegrationUtils.HEADER_NAV_APIKEY, System.getenv(PDL_APIKEY))
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/sts/StsConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/sts/StsConfig.kt
@@ -1,6 +1,7 @@
 package no.nav.sosialhjelp.innsyn.client.sts
 
 import no.nav.sosialhjelp.innsyn.config.ClientProperties
+import no.nav.sosialhjelp.innsyn.utils.HttpClientUtil
 import no.nav.sosialhjelp.innsyn.utils.IntegrationUtils
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -17,12 +18,13 @@ class StsConfig(
 ) {
 
     @Bean
-    fun stsWebClient(nonProxiedWebClientBuilder: WebClient.Builder): WebClient =
-        nonProxiedWebClientBuilder
+    fun stsWebClient(webClientBuilder: WebClient.Builder): WebClient =
+        webClientBuilder
             .baseUrl(clientProperties.stsTokenEndpointUrl)
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic ${credentials()}")
             .defaultHeader(IntegrationUtils.HEADER_NAV_APIKEY, System.getenv(STSTOKEN_APIKEY))
             .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+            .clientConnector(HttpClientUtil.getUnproxiedReactorClientHttpConnector())
             .build()
 
     companion object {

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/tokendings/JwkProviderUtil.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/tokendings/JwkProviderUtil.kt
@@ -18,8 +18,8 @@ fun downloadWellKnown(url: String): WellKnown =
         .block()
         ?: throw RuntimeException("Feiler under henting av well-known konfigurasjon fra $url")
 
-fun buildWebClient(nonProxiedWebClientBuilder: WebClient.Builder, url: String, headers: HttpHeaders = applicationJsonHttpHeaders()): WebClient =
-    nonProxiedWebClientBuilder
+fun buildWebClient(webClientBuilder: WebClient.Builder, url: String, headers: HttpHeaders = applicationJsonHttpHeaders()): WebClient =
+    webClientBuilder
         .baseUrl(url)
         .defaultHeaders { headers.map { it.key to it.value } }
         .clientConnector(

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/tokendings/TokendingsClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/tokendings/TokendingsClientConfig.kt
@@ -14,25 +14,25 @@ class TokendingsWebClient(
 
 @Configuration
 class TokendingsClientConfig(
-    private val clientProperties: ClientProperties,
+    private val clientProperties: ClientProperties
 ) {
     @Bean
     @Profile("!test")
-    fun tokendingsWebClient(nonProxiedWebClientBuilder: WebClient.Builder): TokendingsWebClient {
+    fun tokendingsWebClient(webClientBuilder: WebClient.Builder): TokendingsWebClient {
         val wellKnown = downloadWellKnown(clientProperties.tokendingsUrl)
         log.info("TokendingsClient: Lastet ned well known fra: ${clientProperties.tokendingsUrl} bruker token endpoint: ${wellKnown.tokenEndpoint}")
         return TokendingsWebClient(
-            buildWebClient(nonProxiedWebClientBuilder, wellKnown.tokenEndpoint, applicationFormUrlencodedHeaders()),
+            buildWebClient(webClientBuilder, wellKnown.tokenEndpoint, applicationFormUrlencodedHeaders()),
             wellKnown
         )
     }
 
     @Bean
     @Profile("test")
-    fun tokendingsWebClientTest(nonProxiedWebClientBuilder: WebClient.Builder): TokendingsWebClient {
+    fun tokendingsWebClientTest(webClientBuilder: WebClient.Builder): TokendingsWebClient {
         log.info("TokendingsClient: Setter opp test client som bruker token endpoint: ${clientProperties.tokendingsUrl}")
         return TokendingsWebClient(
-            buildWebClient(nonProxiedWebClientBuilder, clientProperties.tokendingsUrl),
+            buildWebClient(webClientBuilder, clientProperties.tokendingsUrl),
             WellKnown("iss-localhost", "authorizationEndpoint", "tokenEndpoint", clientProperties.tokendingsUrl)
         )
     }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/client/virusscan/VirusScanConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.sosialhjelp.innsyn.client.virusscan
 
+import no.nav.sosialhjelp.innsyn.utils.HttpClientUtil.getUnproxiedReactorClientHttpConnector
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
@@ -8,9 +9,10 @@ import org.springframework.web.reactive.function.client.WebClient
 class VirusScanConfig {
 
     @Bean
-    fun virusScanWebClient(nonProxiedWebClientBuilder: WebClient.Builder) =
-        nonProxiedWebClientBuilder
+    fun virusScanWebClient(webClientBuilder: WebClient.Builder) =
+        webClientBuilder
             .baseUrl(DEFAULT_CLAM_URI)
+            .clientConnector(getUnproxiedReactorClientHttpConnector())
             .build()
 
     companion object {

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/ProxiedWebClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/config/ProxiedWebClientConfig.kt
@@ -1,47 +1,34 @@
 package no.nav.sosialhjelp.innsyn.config
 
-import no.nav.sosialhjelp.innsyn.utils.getProxiedReactorClientHttpConnector
-import no.nav.sosialhjelp.innsyn.utils.getUnproxiedReactorClientHttpConnector
+import no.nav.sosialhjelp.innsyn.utils.HttpClientUtil.getProxiedReactorClientHttpConnector
+import no.nav.sosialhjelp.innsyn.utils.HttpClientUtil.getUnproxiedReactorClientHttpConnector
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile
 import org.springframework.web.reactive.function.client.WebClient
 
-@Configuration
-class NonProxiedWebClientConfig(
-    private val webClientBuilder: WebClient.Builder
-) {
-
-    @Bean("nonProxiedWebClientBuilder")
-    fun nonProxiedWebClientBuilder(): WebClient.Builder =
-        webClientBuilder
-            .clientConnector(getUnproxiedReactorClientHttpConnector())
-}
-
 @Profile("!(mock-alt|local|test)")
 @Configuration
-class ProxiedWebClientConfig(
-    private val webClientBuilder: WebClient.Builder
-) {
+class ProxiedWebClientConfig {
 
     @Value("\${HTTPS_PROXY}")
     private lateinit var proxyUrl: String
 
-    @Bean("proxiedWebClientBuilder")
-    fun proxiedWebClientBuilder(): WebClient.Builder =
+    @Bean
+    fun proxiedWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
             .clientConnector(getProxiedReactorClientHttpConnector(proxyUrl))
+            .build()
 }
 
 @Profile("(mock-alt|local|test)")
 @Configuration
-class MockProxiedWebClientConfig(
-    private val webClientBuilder: WebClient.Builder
-) {
+class MockProxiedWebClientConfig {
 
-    @Bean("proxiedWebClientBuilder")
-    fun proxiedWebClientBuilder(): WebClient.Builder =
+    @Bean
+    fun proxiedWebClient(webClientBuilder: WebClient.Builder): WebClient =
         webClientBuilder
             .clientConnector(getUnproxiedReactorClientHttpConnector())
+            .build()
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/HttpClientUtil.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/HttpClientUtil.kt
@@ -6,21 +6,24 @@ import reactor.netty.http.client.HttpClient
 import reactor.netty.transport.ProxyProvider
 import java.net.URL
 
-fun getProxiedReactorClientHttpConnector(proxyUrl: String): ReactorClientHttpConnector {
-    val uri = URL(proxyUrl)
+object HttpClientUtil {
 
-    val httpClient: HttpClient = HttpClient.create()
-        .resolver(DefaultAddressResolverGroup.INSTANCE)
-        .proxy { proxy ->
-            proxy.type(ProxyProvider.Proxy.HTTP).host(uri.host).port(uri.port)
-        }
+    fun getProxiedReactorClientHttpConnector(proxyUrl: String): ReactorClientHttpConnector {
+        val uri = URL(proxyUrl)
 
-    return ReactorClientHttpConnector(httpClient)
-}
+        val httpClient: HttpClient = HttpClient.create()
+            .resolver(DefaultAddressResolverGroup.INSTANCE)
+            .proxy { proxy ->
+                proxy.type(ProxyProvider.Proxy.HTTP).host(uri.host).port(uri.port)
+            }
 
-fun getUnproxiedReactorClientHttpConnector(): ReactorClientHttpConnector {
-    val httpClient: HttpClient = HttpClient
-        .newConnection()
-        .resolver(DefaultAddressResolverGroup.INSTANCE)
-    return ReactorClientHttpConnector(httpClient)
+        return ReactorClientHttpConnector(httpClient)
+    }
+
+    fun getUnproxiedReactorClientHttpConnector(): ReactorClientHttpConnector {
+        val httpClient: HttpClient = HttpClient
+            .newConnection()
+            .resolver(DefaultAddressResolverGroup.INSTANCE)
+        return ReactorClientHttpConnector(httpClient)
+    }
 }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/ApplicationContextTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/ApplicationContextTest.kt
@@ -15,8 +15,8 @@ class ApplicationContextTest {
     @MockkBean
     private lateinit var idPortenClient: IdPortenClient
 
-    @MockkBean(name = "proxiedWebClientBuilder", relaxed = true)
-    private lateinit var proxiedWebClientBuilder: WebClient.Builder
+    @MockkBean(name = "proxiedWebClient", relaxed = true)
+    private lateinit var proxiedWebClient: WebClient
 
     @MockkBean
     private lateinit var proxiedWebClientConfig: ProxiedWebClientConfig


### PR DESCRIPTION
Bump spring-boot, kotlin, sosialhjelp-common, logback, token-validation, jackson, junit, mockk, micrometer, prometheus

Endrer på ProxiedWebClientConfig for å unngå cyclic dependencies.

Fjerner appdynamics-bruk.