### PR TITLE
bruker maskinporten for å hente dokumentlager-public-key fra Fiks

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingService.kt
@@ -68,7 +68,7 @@ class VedleggOpplastingService(
 
         val krypteringFutureList = Collections.synchronizedList(ArrayList<CompletableFuture<Void>>(filerForOpplasting.size))
         try {
-            val certificate = dokumentlagerClient.getDokumentlagerPublicKeyX509Certificate(token)
+            val certificate = dokumentlagerClient.getDokumentlagerPublicKeyX509Certificate()
             val filerForOpplastingEtterKryptering: List<FilForOpplasting> = filerForOpplasting
                 .map { file ->
                     val inputStream = krypteringService.krypter(file.fil, krypteringFutureList, certificate)

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/IntegrationUtils.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/utils/IntegrationUtils.kt
@@ -14,8 +14,6 @@ object IntegrationUtils {
     const val BEARER = "Bearer "
 
     const val HEADER_CALL_ID = "Nav-Call-Id"
-    const val HEADER_NAV_APIKEY = "x-nav-apiKey"
-    const val HEADER_CONSUMER_TOKEN = "Nav-Consumer-Token"
     const val HEADER_TEMA = "Tema"
 
     const val TEMA_KOM = "KOM"

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/service/vedlegg/VedleggOpplastingServiceTest.kt
@@ -88,7 +88,7 @@ internal class VedleggOpplastingServiceTest {
         every { virusScanner.scan(any(), any()) } just runs
         every { redisService.put(any(), any(), any()) } just runs
         every { redisService.defaultTimeToLiveSeconds } returns 1
-        every { dokumentlagerClient.getDokumentlagerPublicKeyX509Certificate(any()) } returns mockCertificate
+        every { dokumentlagerClient.getDokumentlagerPublicKeyX509Certificate() } returns mockCertificate
         every { unleashClient.isEnabled(any(), false) } returns true
     }
 


### PR DESCRIPTION
 Cacher samtidig X509Certificate i DokumentlagerClient. Siste 24h har vi hentet public-keyen 2234 ganger - det burde ikke være nødvendig!