### PR TITLE
default clientId for mock-alt

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/common/subjecthandler/SubjectHandler.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/common/subjecthandler/SubjectHandler.kt
@@ -39,7 +39,7 @@ class AzureAdSubjectHandlerImpl(
     }
 
     override fun getClientId(): String {
-        return tokenValidationContext.getClaims(ISSUER).getStringClaim(CLIENT_ID)
+        return tokenValidationContext.getClaims(ISSUER).getStringClaim(CLIENT_ID) ?: DEFAULT_CLIENT_ID
     }
 
     override fun getConsumerId(): String {
@@ -50,6 +50,7 @@ class AzureAdSubjectHandlerImpl(
         private const val ISSUER = "selvbetjening"
         private const val PID = "pid"
         private const val CLIENT_ID = "client_id"
+        private const val DEFAULT_CLIENT_ID = "clientId"
         private val log by logger()
     }
 }


### PR DESCRIPTION
trenger en default-value lik `login_api_idporten_clientid` for mock-alt, ellers vil tilgangskontroll feile med validering av login-api's clientId når #513 flettes inn