### PR TITLE
Logger hvis søknad har mottatt-status men ikke har hatt sendt-status

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/oppgaver/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/oppgaver/OppgaveService.kt
@@ -229,6 +229,16 @@ class OppgaveService(
         return avsenderVersion >= godkjentVersion
     }
 
+    fun sakHarStatusMottattOgIkkeHattSendt(fiksDigisosId: String, token: String): Boolean {
+        val digisosSak = fiksClient.hentDigisosSak(fiksDigisosId, token, true)
+        val model = eventService.createModel(digisosSak, token)
+        if (model.status == null || model.status != SoknadsStatus.MOTTATT) {
+            return false
+        }
+
+        return model.historikk.filter { hendelse -> hendelse.tittel.startsWith("Søknaden med vedlegg er sendt til") }.isEmpty()
+    }
+
     companion object {
         private val log by logger()
     }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
@@ -63,7 +63,7 @@ class SaksOversiktController(
             if (saker.isNotEmpty() && oppgaveService.getFagsystemHarVilkarOgDokumentasjonkrav(
                     saker[0].fiksDigisosId,
                     token
-                )
+                ) && oppgaveService.sakHarStatusMottattOgIkkeHattSendt(saker[0].fiksDigisosId, token)
             ) {
                 log.info("Kommune med kommunenummer ${saker[0].kommunenummer} har fagsystemversjon som støtter innsyn i papirsøknader")
             }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/digisossak/oppgaver/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/digisossak/oppgaver/OppgaveServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.sosialhjelp.innsyn.app.ClientProperties
 import no.nav.sosialhjelp.innsyn.digisosapi.FiksClient
 import no.nav.sosialhjelp.innsyn.domain.Dokumentasjonkrav
 import no.nav.sosialhjelp.innsyn.domain.Fagsystem
+import no.nav.sosialhjelp.innsyn.domain.Hendelse
 import no.nav.sosialhjelp.innsyn.domain.InternalDigisosSoker
 import no.nav.sosialhjelp.innsyn.domain.Oppgave
 import no.nav.sosialhjelp.innsyn.domain.Oppgavestatus
@@ -730,5 +731,28 @@ internal class OppgaveServiceTest {
         val response = service.getFagsystemHarVilkarOgDokumentasjonkrav("123", token)
 
         assertThat(response).isFalse
+    }
+
+    @Test
+    fun `should return true if soknad har mottat-status og ikke har hatt SENDT-status`() {
+        val model = InternalDigisosSoker()
+        model.status = SoknadsStatus.MOTTATT
+        model.historikk.add(Hendelse("Søknaden kommer kanskje fra papirsøknad", LocalDateTime.now(), null))
+        every { eventService.createModel(any(), any()) } returns model
+
+        val sakHarStatusMottattOgIkkeHattSendt = service.sakHarStatusMottattOgIkkeHattSendt("123", token)
+        assertThat(sakHarStatusMottattOgIkkeHattSendt).isTrue
+    }
+
+    @Test
+    fun `should return false if soknad har mottat-status og har hatt SENDT-status`() {
+        val model = InternalDigisosSoker()
+        model.status = SoknadsStatus.MOTTATT
+        model.historikk.add(Hendelse("Random hendelse", LocalDateTime.now(), null))
+        model.historikk.add(Hendelse("Søknaden med vedlegg er sendt til test kommune", LocalDateTime.now(), null))
+        every { eventService.createModel(any(), any()) } returns model
+
+        val sakHarStatusMottattOgIkkeHattSendt = service.sakHarStatusMottattOgIkkeHattSendt("123", token)
+        assertThat(sakHarStatusMottattOgIkkeHattSendt).isFalse
     }
 }


### PR DESCRIPTION
Logg-melding skal fjernes når vi har fått nok data på fagsystemer som antakeligvis har papirsøknader