### PR TITLE
øker maxDepthPerThrowable

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -5,7 +5,7 @@
         <appender name="stdout_json" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
-                    <maxDepthPerThrowable>10</maxDepthPerThrowable>
+                    <maxDepthPerThrowable>30</maxDepthPerThrowable>
                 </throwableConverter>
             </encoder>
         </appender>


### PR DESCRIPTION
Kanskje EofException eller InterruptedException kan bedre forklares med lengre stacktraces