### PR TITLE
rydder litt i bruk av test spring profile

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/maskinporten/MaskinportenClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/maskinporten/MaskinportenClientConfig.kt
@@ -5,7 +5,6 @@ import no.nav.sosialhjelp.innsyn.utils.objectMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
@@ -24,15 +23,8 @@ class MaskinportenClientConfig(
 ) {
 
     @Bean
-    @Profile("!test")
     fun maskinportenClient(): MaskinportenClient {
         return MaskinportenClient(maskinportenWebClient, maskinportenProperties, wellknown)
-    }
-
-    @Bean
-    @Profile("test")
-    fun maskinportenClientTest(): MaskinportenClient {
-        return MaskinportenClient(maskinportenWebClient, maskinportenProperties, WellKnown("issuer", "token_url"))
     }
 
     private val maskinportenWebClient: WebClient =

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/tokendings/TokendingsClientConfig.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/tokendings/TokendingsClientConfig.kt
@@ -4,7 +4,6 @@ import no.nav.sosialhjelp.innsyn.app.ClientProperties
 import no.nav.sosialhjelp.kotlin.utils.logger
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.web.reactive.function.client.WebClient
 
 class TokendingsWebClient(
@@ -17,23 +16,12 @@ class TokendingsClientConfig(
     private val clientProperties: ClientProperties
 ) {
     @Bean
-    @Profile("!test")
     fun tokendingsWebClient(webClientBuilder: WebClient.Builder): TokendingsWebClient {
         val wellKnown = downloadWellKnown(clientProperties.tokendingsUrl)
         log.info("TokendingsClient: Lastet ned well known fra: ${clientProperties.tokendingsUrl} bruker token endpoint: ${wellKnown.tokenEndpoint}")
         return TokendingsWebClient(
             buildWebClient(webClientBuilder, wellKnown.tokenEndpoint, applicationFormUrlencodedHeaders()),
             wellKnown
-        )
-    }
-
-    @Bean
-    @Profile("test")
-    fun tokendingsWebClientTest(webClientBuilder: WebClient.Builder): TokendingsWebClient {
-        log.info("TokendingsClient: Setter opp test client som bruker token endpoint: ${clientProperties.tokendingsUrl}")
-        return TokendingsWebClient(
-            buildWebClient(webClientBuilder, clientProperties.tokendingsUrl),
-            WellKnown("iss-localhost", "authorizationEndpoint", "tokenEndpoint", clientProperties.tokendingsUrl)
         )
     }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,17 +13,18 @@ client:
   unleash_url: "http://localhost:58888"
   unleash_instance_id: "local"
   meldinger_kommunenummer: "0301"
-  tokendings_url: "http://localhost:59999"
+  tokendings_url: http://localhost:${mock-oauth2-server.port}/tokenx/.well-known/openid-configuration
+  tokendings_client_id: localhost:teamdigisos:sosialhjelp-dialog-api
+  tokendings_private_jwk: generateRSA
   dialog_endpoint_url: "http://localhost:59999"
   dialog_audience: "dialog"
-  tokendings_private_jwk: "generateRSA"
   soknad_api_url: "http://localhost:59999"
   soknad_api_audience: "soknadAudience"
 
 #Maskinporten
 maskinporten_clientid: clientid
 maskinporten_scopes: scopes
-maskinporten_well_known_url: ${MASKINPORTEN_WELL_KNOWN_URL:https://maskinporten}
+maskinporten_well_known_url: http://localhost:${mock-oauth2-server.port}/maskinporten/.well-known/openid-configuration
 maskinporten_client_jwk: generateRSA
 
 innsyn:


### PR DESCRIPTION
Tar i bruk mock-oauth2-server sine well-known urler fremfor å unødvendig konfigurere egne bønner for `test`-profil