### PR TITLE
disable idporten i dev-fss.

### DIFF
--- a/nais/dev/dev-fss.json
+++ b/nais/dev/dev-fss.json
@@ -44,5 +44,5 @@
   "isMock": false,
   "tokenXEnabled": true,
   "maskinportenEnabled": true,
-  "idportenEnabled": true
+  "idportenEnabled": false
 }


### PR DESCRIPTION
Siden det blir vanskelig å aktivere #607 i FSS, deaktiveres idporten-feature i nais.yaml for dev-fss inntil videre. Den er ikke bruk enda, så kan trygt disables.
Denne featuren krever kun 1 ingress - men nå har vi ingresser på dev.intern.nav.no og dev-fss-pub.nais.io