### PR TITLE
Rydder i ubrukte feature-toggles

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/featuretoggle/ToggleNames.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/featuretoggle/ToggleNames.kt
@@ -1,10 +1,7 @@
 package no.nav.sosialhjelp.innsyn.app.featuretoggle
 
 const val VILKAR_ENABLED = "sosialhjelp.innsyn.vilkar-enabled"
-const val VILKAR = "sosialhjelp.innsyn.vilkar"
 const val DOKUMENTASJONKRAV_ENABLED = "sosialhjelp.innsyn.dokumentasjonkrav-enabled"
-const val DOKUMENTASJONKRAV = "sosialhjelp.innsyn.dokumentasjonkrav"
-const val UTVIDE_VEDLEGG_JSON = "sosialhjelp.innsyn.utvide-vedlegg-json"
 const val LOGGE_MISMATCH_FILNAVN = "sosialhjelp.innsyn.logge-mismatch-filnavn"
 
 const val FAGSYSTEM_MED_INNSYN_I_PAPIRSOKNADER = "sosialhjelp.innsyn.fagsystem-med-papirsoknader-loggmelding"

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonkravTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonkravTest.kt
@@ -8,7 +8,6 @@ import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
 import no.nav.sosialhjelp.api.fiks.DigisosSak
 import no.nav.sosialhjelp.innsyn.app.ClientProperties
-import no.nav.sosialhjelp.innsyn.app.featuretoggle.DOKUMENTASJONKRAV
 import no.nav.sosialhjelp.innsyn.app.featuretoggle.DOKUMENTASJONKRAV_ENABLED
 import no.nav.sosialhjelp.innsyn.domain.Oppgavestatus
 import no.nav.sosialhjelp.innsyn.domain.SoknadsStatus
@@ -56,7 +55,6 @@ internal class DokumentasjonkravTest {
         every { mockDigisosSak.originalSoknadNAV?.soknadDokument?.dokumentlagerDokumentId } returns null
 
         every { unleashClient.isEnabled(DOKUMENTASJONKRAV_ENABLED, false) } returns true
-        every { unleashClient.isEnabled(DOKUMENTASJONKRAV, false) } returns true
 
         resetHendelser()
     }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/VilkarTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/VilkarTest.kt
@@ -8,7 +8,6 @@ import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
 import no.nav.sosialhjelp.api.fiks.DigisosSak
 import no.nav.sosialhjelp.innsyn.app.ClientProperties
-import no.nav.sosialhjelp.innsyn.app.featuretoggle.VILKAR
 import no.nav.sosialhjelp.innsyn.domain.Oppgavestatus
 import no.nav.sosialhjelp.innsyn.domain.SoknadsStatus
 import no.nav.sosialhjelp.innsyn.navenhet.NavEnhet
@@ -51,7 +50,6 @@ internal class VilkarTest {
         every { innsynService.hentOriginalSoknad(any(), any()) } returns mockJsonSoknad
         every { norgClient.hentNavEnhet(enhetsnr) } returns mockNavEnhet
 
-        every { unleashClient.isEnabled(VILKAR, false) } returns true
         resetHendelser()
     }
 


### PR DESCRIPTION
Etterpå kan `sosialhjelp.innsyn.dokumentasjonkrav`, `sosialhjelp.innsyn.utvide-vedlegg-json` og `sosialhjelp.innsyn.vilkar` fjernes fra unleash