### PR TITLE
overskriver MASKINPORTEN_WELL_KNOWN_URL i dev-fss

### DIFF
--- a/nais/dev/dev-fss.yaml
+++ b/nais/dev/dev-fss.yaml
@@ -90,3 +90,5 @@ spec:
       value: "http://sosialhjelp-soknad-api/sosialhjelp/soknad-api"
     - name: SOKNAD_API_AUDIENCE
       value: "dev-fss:teamdigisos:sosialhjelp-soknad-api"
+    - name: MASKINPORTEN_WELL_KNOWN_URL
+      value: "https://ver2.maskinporten.no/.well-known/oauth-authorization-server"


### PR DESCRIPTION
ettersom KS ikke støtter ny issuer enda