### PR TITLE
Nedgraderer logg-melding ved 404 fra Fiks til warning

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/exceptions/InnsynExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/app/exceptions/InnsynExceptionHandler.kt
@@ -47,7 +47,7 @@ class InnsynExceptionHandler(
 
     @ExceptionHandler(FiksNotFoundException::class)
     fun handleFiksNotFoundError(e: FiksNotFoundException): ResponseEntity<FrontendErrorMessage> {
-        log.error(e.message, e)
+        log.warn(e.message, e)
         val error = FrontendErrorMessage(FIKS_ERROR, "DigisosSak finnes ikke")
         return ResponseEntity(error, HttpStatus.NOT_FOUND)
     }


### PR DESCRIPTION
For å slippe å spamme alertskanalen. Kan vurdere å endre tilbake til error når vi får fiksa antall requester på digisosId med fnr ikke tilhørende bruker..