### PR TITLE
Erstatter tab-tegn med space i dokumenttype

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonEtterspurt.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/DokumentasjonEtterspurt.kt
@@ -38,6 +38,10 @@ fun InternalDigisosSoker.apply(
             }
             .toMutableList()
 
+    oppgaver.filter { it.tittel.contains(Regex("[^a-zA-ZæøåÆØÅ\\d :]")) }.onEach {
+        log.warn("Oppgavetittel inneholder")
+    }
+
     if (status == SoknadsStatus.FERDIGBEHANDLET) {
         log.warn("Dokumentasjon etterspurt etter at søknad er satt til ferdigbehandlet. fiksDigisosId: $fiksDigisosId")
     }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/pdf/EttersendelsePdfGenerator.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/pdf/EttersendelsePdfGenerator.kt
@@ -9,7 +9,7 @@ import java.time.LocalDateTime
 @Component
 class EttersendelsePdfGenerator {
     fun generate(
-        metadata: MutableList<OpplastetVedleggMetadata>,
+        metadata: List<OpplastetVedleggMetadata>,
         fodselsnummer: String,
     ): ByteArray {
         return try {
@@ -30,7 +30,8 @@ class EttersendelsePdfGenerator {
 
                 metadata.forEach { vedlegg ->
                     pdf.addBlankLine()
-                    pdf.addText("Type: " + vedlegg.type)
+                    // Replace tab-character (\t or U+0009) bacause there is no glyph for that in the font we use (SourceSansPro-Regular)
+                    pdf.addText("Type: " + vedlegg.type.replace(Regex("\\x09"), " "))
                     vedlegg.filer.forEach { fil ->
                         pdf.addText("Filnavn: " + fil.filnavn)
                     }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/VedleggOpplastingServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/VedleggOpplastingServiceTest.kt
@@ -53,7 +53,6 @@ internal class VedleggOpplastingServiceTest {
             redisService,
             ettersendelsePdfGenerator,
             dokumentlagerClient,
-            unleashClient,
         )
 
     private val mockDigisosSak: DigisosSak = mockk(relaxed = true)

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/pdf/EttersendelsePdfGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/pdf/EttersendelsePdfGeneratorTest.kt
@@ -4,6 +4,7 @@ import no.nav.sosialhjelp.innsyn.vedlegg.OpplastetVedleggMetadata
 import org.apache.pdfbox.Loader
 import org.apache.pdfbox.pdfwriter.compress.CompressParameters
 import org.apache.pdfbox.preflight.parser.PreflightParser
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ class EttersendelsePdfGeneratorTest {
 
     @Test
     fun `skal generere pdfA`() {
-        val metadata = Collections.emptyList<OpplastetVedleggMetadata>()
+        val metadata = emptyList<OpplastetVedleggMetadata>()
 
         val bytes = ettersendelsePdfGenerator.generate(metadata, ident)
         val file = File("pdfaTest.pdf")
@@ -46,5 +47,14 @@ class EttersendelsePdfGeneratorTest {
         val result = PreflightParser.validate(file)
 
         Assertions.assertTrue(result.isValid)
+    }
+
+    @Test
+    fun `Ingen exception ved vedleggstype som inneholder en tabular`() {
+        val metadata: List<OpplastetVedleggMetadata> = listOf(OpplastetVedleggMetadata("\tabc", null, null, null, mutableListOf(), null))
+
+        val bytesResult = runCatching { ettersendelsePdfGenerator.generate(metadata, ident) }
+
+        assertThat(bytesResult.isSuccess).isTrue()
     }
 }


### PR DESCRIPTION
Fonten (SourceSansPro-Regular) støtter ikke U+0009 (tab), så vi erstatter tabs i dokumenttype som kommer fra fagsystemet med space