### PR TITLE
Flytter saksdetaljer-URL til sak/{fiksDigisosId}/detaljer

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
@@ -62,24 +62,25 @@ class SaksOversiktController(
     fun getSaksDetaljer(
         @RequestParam fiksDigisosId: String,
         @RequestHeader(value = HttpHeaders.AUTHORIZATION) token: String,
-    ): SaksDetaljerResponse = runBlocking {
-        withContext(MDCContext() + RequestAttributesContext()) {
-            tilgangskontroll.sjekkTilgang(token)
+    ): SaksDetaljerResponse =
+        runBlocking {
+            withContext(MDCContext() + RequestAttributesContext()) {
+                tilgangskontroll.sjekkTilgang(token)
 
-            val sak = fiksClient.hentDigisosSak(fiksDigisosId, token)
-            val model = eventService.createSaksoversiktModel(sak, token)
-            val antallOppgaver =
-                hentAntallNyeOppgaver(model, sak.fiksDigisosId, token) +
-                    hentAntallNyeVilkarOgDokumentasjonkrav(model, sak.fiksDigisosId, token)
+                val sak = fiksClient.hentDigisosSak(fiksDigisosId, token)
+                val model = eventService.createSaksoversiktModel(sak, token)
+                val antallOppgaver =
+                    hentAntallNyeOppgaver(model, sak.fiksDigisosId, token) +
+                        hentAntallNyeVilkarOgDokumentasjonkrav(model, sak.fiksDigisosId, token)
 
-            return@withContext SaksDetaljerResponse(
-                sak.fiksDigisosId,
-                hentNavn(model),
-                model.status.name,
-                antallOppgaver,
-            )
+                return@withContext SaksDetaljerResponse(
+                    sak.fiksDigisosId,
+                    hentNavn(model),
+                    model.status.name,
+                    antallOppgaver,
+                )
+            }
         }
-    }
 
     @Validated
     @Deprecated("Bruk /sak/:fiksDigisosId/detaljer")

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktController.kt
@@ -23,6 +23,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -58,9 +59,9 @@ class SaksOversiktController(
             }
         }
 
-    @GetMapping("/sak/:fiksDigisosId/detaljer")
+    @GetMapping("/sak/{fiksDigisosId}/detaljer")
     fun getSaksDetaljer(
-        @RequestParam fiksDigisosId: String,
+        @PathVariable fiksDigisosId: String,
         @RequestHeader(value = HttpHeaders.AUTHORIZATION) token: String,
     ): SaksDetaljerResponse =
         runBlocking {
@@ -73,7 +74,7 @@ class SaksOversiktController(
                     hentAntallNyeOppgaver(model, sak.fiksDigisosId, token) +
                         hentAntallNyeVilkarOgDokumentasjonkrav(model, sak.fiksDigisosId, token)
 
-                return@withContext SaksDetaljerResponse(
+                SaksDetaljerResponse(
                     sak.fiksDigisosId,
                     hentNavn(model),
                     model.status.name,

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktControllerTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/saksoversikt/SaksOversiktControllerTest.kt
@@ -134,22 +134,18 @@ internal class SaksOversiktControllerTest {
             every { model1.utbetalinger } returns mutableListOf()
             every { model2.utbetalinger } returns mutableListOf()
 
-            val response1 = controller.hentSaksDetaljer("123", "token")
-            val sak1 = response1.body
+            val sak1 = controller.getSaksDetaljer("123", "token")
 
-            assertThat(response1.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(sak1).isNotNull
-            assertThat(sak1?.soknadTittel).isEqualTo("")
-            assertThat(sak1?.antallNyeOppgaver).isEqualTo(6)
+            assertThat(sak1.soknadTittel).isEqualTo("")
+            assertThat(sak1.antallNyeOppgaver).isEqualTo(6)
 
-            val response2 = controller.hentSaksDetaljer("456", "token")
-            val sak2 = response2.body
+            val sak2 = controller.getSaksDetaljer("456", "token")
 
-            assertThat(response2.statusCode).isEqualTo(HttpStatus.OK)
             assertThat(sak2).isNotNull
-            assertThat(sak2?.soknadTittel).contains("Livsopphold", "Strøm")
-            assertThat(sak2?.status).isEqualTo("UNDER_BEHANDLING")
-            assertThat(sak2?.antallNyeOppgaver).isEqualTo(3)
+            assertThat(sak2.soknadTittel).contains("Livsopphold", "Strøm")
+            assertThat(sak2.status).isEqualTo("UNDER_BEHANDLING")
+            assertThat(sak2.antallNyeOppgaver).isEqualTo(3)
         }
 
     @Test
@@ -165,14 +161,12 @@ internal class SaksOversiktControllerTest {
             every { model1.saker } returns mutableListOf()
             every { model1.utbetalinger } returns mutableListOf()
 
-            val response = controller.hentSaksDetaljer(digisosSak1.fiksDigisosId, "token")
-            val sak = response.body
+            val sak = controller.getSaksDetaljer(digisosSak1.fiksDigisosId, "token")
 
             assertThat(sak).isNotNull
-            assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
 
             verify { oppgaveService wasNot Called }
 
-            assertThat(sak?.antallNyeOppgaver).isEqualTo(0)
+            assertThat(sak.antallNyeOppgaver).isEqualTo(0)
         }
 }


### PR DESCRIPTION
Ingen grunn til at digisosId skal være query-parameter

Fjerner også ResponseEntity; det er smør på flesk når man ikke manuelt setter HTTP-koder eller gjør andre lavnivå operasjoner på responsen.

Fjerner også manuell sjekk av id:

```
   if (id.isEmpty()) {
       return@withContext ResponseEntity.noContent().build()
   }
```

til fordel for Jakarta-validering med @Validated og @NotBlank.