### PR TITLE
Håndter cancellation exceptions riktig

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/KrypteringService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/KrypteringService.kt
@@ -1,7 +1,10 @@
 package no.nav.sosialhjelp.innsyn.vedlegg
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import no.ks.kryptering.CMSKrypteringImpl
 import no.nav.sosialhjelp.innsyn.utils.logger
@@ -39,6 +42,7 @@ class KrypteringServiceImpl : KrypteringService {
                     kryptering.krypterData(pos, fileInputStream, certificate, Security.getProvider("BC"))
                     log.debug("Ferdig med kryptering")
                 } catch (e: Exception) {
+                    if (e is CancellationException) currentCoroutineContext().ensureActive()
                     log.error("Det skjedde en feil ved kryptering, exception blir lagt til kryptert InputStream", e)
                     throw IllegalStateException("An error occurred during encryption", e)
                 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/VedleggOpplastingService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/VedleggOpplastingService.kt
@@ -1,9 +1,12 @@
 package no.nav.sosialhjelp.innsyn.vedlegg
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withTimeout
 import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonFiler
 import no.nav.sbl.soknadsosialhjelp.vedlegg.JsonVedlegg
@@ -111,6 +114,7 @@ class VedleggOpplastingService(
                 ettersendelsePdf.inputStream(),
             )
         } catch (e: Exception) {
+            if (e is CancellationException) currentCoroutineContext().ensureActive()
             log.error("Generering av ettersendelse.pdf feilet.", e)
             throw e
         }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/virusscan/VirusScanner.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/vedlegg/virusscan/VirusScanner.kt
@@ -1,6 +1,9 @@
 package no.nav.sosialhjelp.innsyn.vedlegg.virusscan
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import kotlinx.coroutines.withContext
 import no.nav.sosialhjelp.innsyn.app.MiljoUtils.isRunningInProd
@@ -66,6 +69,7 @@ class VirusScanner(
             log.warn("Fant virus med status ${scanResult.result} i fil forsøkt opplastet")
             return true
         } catch (e: Exception) {
+            if (e is CancellationException) currentCoroutineContext().ensureActive()
             log.warn("Kunne ikke scanne fil opplastet", e)
             return false
         }


### PR DESCRIPTION
Hvis man ikke rethrower CancellationExceptions i courutines så kan man ende opp med såkalte rogue coroutines som suspender evig. Se https://github.com/Kotlin/kotlinx.coroutines/issues/3658 for mer info