### PR TITLE
Gjør utbetalingsreferansen tilgjengelig for frontend slik at det er enklere å skille mellom utbetalingene når de skal vises

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/utbetalinger/UtbetalingerResponse.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/utbetalinger/UtbetalingerResponse.kt
@@ -22,6 +22,7 @@ data class NyeOgTidligereUtbetalingerResponse(
 )
 
 data class ManedUtbetaling(
+    val referanse: String,
     val tittel: String,
     val belop: BigDecimal,
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/utbetalinger/UtbetalingerService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisossak/utbetalinger/UtbetalingerService.kt
@@ -145,6 +145,7 @@ class UtbetalingerService(
             .map { utbetaling ->
                 utbetaling.infoLoggVedManglendeUtbetalingsDatoEllerForfallsDato(digisosSak.kommunenummer)
                 ManedUtbetaling(
+                    referanse = utbetaling.referanse,
                     tittel = utbetaling.beskrivelse ?: UTBETALING_DEFAULT_TITTEL,
                     belop = utbetaling.belop,
                     utbetalingsdato = utbetaling.utbetalingsDato,


### PR DESCRIPTION
Er en del av: https://github.com/navikt/sosialhjelp-innsyn/pull/1224