### PR TITLE
Batche bulk-innhenting

### DIFF
--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisosapi/FiksService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisosapi/FiksService.kt
@@ -50,6 +50,8 @@ class FiksService(
     suspend fun getAllSoknader(): List<DigisosSak> = fiksClient.hentAlleDigisosSaker()
 
     suspend fun getAllInnsynsfiler(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> {
+        log.info("Tråd ${Thread.currentThread().name}: Henter alle innsynsfiler for ${saker.size} saker")
+
         if (saker.isEmpty()) {
             return emptyMap()
         }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisosapi/FiksService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/digisosapi/FiksService.kt
@@ -50,8 +50,6 @@ class FiksService(
     suspend fun getAllSoknader(): List<DigisosSak> = fiksClient.hentAlleDigisosSaker()
 
     suspend fun getAllInnsynsfiler(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> {
-        log.info("Tråd ${Thread.currentThread().name}: Henter alle innsynsfiler for ${saker.size} saker")
-
         if (saker.isEmpty()) {
             return emptyMap()
         }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
@@ -1,5 +1,9 @@
 package no.nav.sosialhjelp.innsyn.event
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.withContext
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
 import no.nav.sosialhjelp.api.fiks.DigisosSak
@@ -36,7 +40,17 @@ class InnsynService(
         }
     }
 
-    suspend fun hentJsonDigisosSokerBulk(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> = fiksService.getAllInnsynsfiler(saker)
+    suspend fun hentJsonDigisosSokerBulk(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> {
+        return withContext(Dispatchers.IO) {
+            buildMap {
+                saker
+                    .chunked(CHUNK_SIZE)
+                    .map { chunk -> async { fiksService.getAllInnsynsfiler(chunk) } }
+                    .awaitAll()
+                    .forEach { putAll(it) }
+            }
+        }
+    }
 
     suspend fun hentOriginalSoknad(digisosSak: DigisosSak): JsonSoknad? {
         val originalMetadataId = digisosSak.originalSoknadNAV?.metadata
@@ -54,5 +68,6 @@ class InnsynService(
 
     companion object {
         private val log by logger()
+        const val CHUNK_SIZE = 25
     }
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
@@ -40,8 +40,8 @@ class InnsynService(
         }
     }
 
-    suspend fun hentJsonDigisosSokerBulk(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> {
-        return withContext(Dispatchers.IO) {
+    suspend fun hentJsonDigisosSokerBulk(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> =
+        withContext(Dispatchers.IO) {
             buildMap {
                 saker
                     .chunked(CHUNK_SIZE)
@@ -50,7 +50,6 @@ class InnsynService(
                     .forEach { putAll(it) }
             }
         }
-    }
 
     suspend fun hentOriginalSoknad(digisosSak: DigisosSak): JsonSoknad? {
         val originalMetadataId = digisosSak.originalSoknadNAV?.metadata

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
@@ -1,8 +1,11 @@
 package no.nav.sosialhjelp.innsyn.event
 
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.fold
 import kotlinx.coroutines.withContext
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sbl.soknadsosialhjelp.soknad.JsonSoknad
@@ -40,15 +43,18 @@ class InnsynService(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     suspend fun hentJsonDigisosSokerBulk(saker: List<DigisosSak>): Map<String, JsonDigisosSoker> =
         withContext(Dispatchers.IO) {
-            buildMap {
-                saker
-                    .chunked(CHUNK_SIZE)
-                    .map { chunk -> async { fiksService.getAllInnsynsfiler(chunk) } }
-                    .awaitAll()
-                    .forEach { putAll(it) }
-            }
+            saker
+                .chunked(CHUNK_SIZE)
+                .asFlow()
+                .flatMapMerge(concurrency = MAX_CONCURRENT_CHUNK_REQUESTS) { chunk ->
+                    flow { emit(fiksService.getAllInnsynsfiler(chunk)) }
+                }
+                .fold(mutableMapOf<String, JsonDigisosSoker>()) { acc, chunkMap ->
+                    acc.apply { putAll(chunkMap) }
+                }
         }
 
     suspend fun hentOriginalSoknad(digisosSak: DigisosSak): JsonSoknad? {
@@ -68,5 +74,6 @@ class InnsynService(
     companion object {
         private val log by logger()
         const val CHUNK_SIZE = 25
+        const val MAX_CONCURRENT_CHUNK_REQUESTS = 10
     }
 }

--- a/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
+++ b/src/main/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynService.kt
@@ -51,8 +51,7 @@ class InnsynService(
                 .asFlow()
                 .flatMapMerge(concurrency = MAX_CONCURRENT_CHUNK_REQUESTS) { chunk ->
                     flow { emit(fiksService.getAllInnsynsfiler(chunk)) }
-                }
-                .fold(mutableMapOf<String, JsonDigisosSoker>()) { acc, chunkMap ->
+                }.fold(mutableMapOf<String, JsonDigisosSoker>()) { acc, chunkMap ->
                     acc.apply { putAll(chunkMap) }
                 }
         }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynServiceTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/event/InnsynServiceTest.kt
@@ -13,9 +13,12 @@ import no.nav.sosialhjelp.api.fiks.DigisosSoker
 import no.nav.sosialhjelp.api.fiks.OriginalSoknadNAV
 import no.nav.sosialhjelp.innsyn.digisosapi.FiksService
 import no.nav.sosialhjelp.innsyn.kommuneinfo.KommuneService
+import no.nav.sosialhjelp.innsyn.responses.ok_digisossak_response
+import no.nav.sosialhjelp.innsyn.utils.sosialhjelpJsonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 
 internal class InnsynServiceTest {
@@ -89,5 +92,44 @@ internal class InnsynServiceTest {
 
             assertThat(service.hentJsonDigisosSoker(digisosSak)).isNull()
             coVerify(exactly = 0) { fiksService.getDocument(any(), any(), JsonDigisosSoker::class.java, any()) }
+        }
+
+    @Test
+    suspend fun `Bulk-innehenting skal deles opp i chunks`() {
+        val antallSaker = 504
+        val digisosSaker = createDigisosSaker(antallSaker)
+
+        digisosSaker
+            .chunked(InnsynService.CHUNK_SIZE)
+            .forEach { saker -> coEvery { fiksService.getAllInnsynsfiler(saker) } returns saker.mapToJsonDigisosSoker() }
+
+        service
+            .hentJsonDigisosSokerBulk(digisosSaker)
+            .keys
+            .also { keys ->
+                assertThat(keys.size).isEqualTo(antallSaker)
+                digisosSaker
+                    .map { sak -> sak.fiksDigisosId }
+                    .containsAll(keys)
+            }
+
+        val add = if (digisosSaker.size % InnsynService.CHUNK_SIZE == 0) 0 else 1
+        coVerify(exactly = ((digisosSaker.size / InnsynService.CHUNK_SIZE) + add)) { fiksService.getAllInnsynsfiler(any()) }
+    }
+
+    private fun createDigisosSaker(n: Int): List<DigisosSak> =
+        buildList {
+            for (i in 1..n) {
+                sosialhjelpJsonMapper
+                    .readValue(ok_digisossak_response, DigisosSak::class.java)
+                    .copy(fiksDigisosId = UUID.randomUUID().toString(), sokerFnr = i.toString())
+                    .also { add(it) }
+            }
+        }.toList()
+
+    private fun List<DigisosSak>.mapToJsonDigisosSoker(): Map<String, JsonDigisosSoker> =
+        associate {
+            val jsonDigisosSoker: JsonDigisosSoker = mockk()
+            it.fiksDigisosId to jsonDigisosSoker
         }
 }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
@@ -4,7 +4,6 @@ import com.ninjasquad.springmockk.MockkBean
 import com.ninjasquad.springmockk.MockkSpyBean
 import io.getunleash.Unleash
 import io.mockk.coEvery
-import io.mockk.coVerify
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sosialhjelp.api.fiks.DigisosSak
 import no.nav.sosialhjelp.api.fiks.KommuneInfo
@@ -21,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
-import java.util.UUID
 
 class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
     @Autowired
@@ -214,23 +212,4 @@ class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
         assertThat(unikeUtbetalinger).hasSize(3)
         assertThat(unikeUtbetalinger).allMatch { it.tilknyttedeSoknader.size == 1 }
     }
-
-    @Test
-    suspend fun `Bulk-innehenting skal deles opp i chunks`() {
-        coEvery { fiksService.getAllInnsynsfiler(any()) } returns emptyMap()
-
-        innsynService.hentJsonDigisosSokerBulk(createDigisosSaker(504))
-
-        coVerify(exactly = 21) { fiksService.getAllInnsynsfiler(any()) }
-    }
-
-    private fun createDigisosSaker(n: Int): List<DigisosSak> =
-        buildList {
-            for (i in 1..n) {
-                sosialhjelpJsonMapper
-                    .readValue(ok_digisossak_response, DigisosSak::class.java)
-                    .copy(fiksDigisosId = UUID.randomUUID().toString(), sokerFnr = i.toString())
-                    .also { add(it) }
-            }
-        }.toList()
 }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
@@ -1,14 +1,17 @@
 package no.nav.sosialhjelp.innsyn.integrasjonstest
 
 import com.ninjasquad.springmockk.MockkBean
+import com.ninjasquad.springmockk.MockkSpyBean
 import io.getunleash.Unleash
 import io.mockk.coEvery
+import io.mockk.coVerify
 import no.nav.sbl.soknadsosialhjelp.digisos.soker.JsonDigisosSoker
 import no.nav.sosialhjelp.api.fiks.DigisosSak
 import no.nav.sosialhjelp.api.fiks.KommuneInfo
 import no.nav.sosialhjelp.innsyn.digisosapi.FiksService
 import no.nav.sosialhjelp.innsyn.digisossak.utbetalinger2.UtbetalingDto
 import no.nav.sosialhjelp.innsyn.domain.UtbetalingsStatus
+import no.nav.sosialhjelp.innsyn.event.InnsynService
 import no.nav.sosialhjelp.innsyn.kommuneinfo.KommuneInfoClient
 import no.nav.sosialhjelp.innsyn.responses.ok_digisossak_response
 import no.nav.sosialhjelp.innsyn.responses.ok_digisossak_response2
@@ -16,10 +19,17 @@ import no.nav.sosialhjelp.innsyn.utils.sosialhjelpJsonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
+import java.util.UUID
 
-class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
-    @MockkBean
+class UtbetalingerIntegrasjonsTest(
+) : AbstractIntegrationTest() {
+
+    @Autowired
+    private lateinit var innsynService: InnsynService
+
+    @MockkSpyBean
     private lateinit var fiksService: FiksService
 
     @MockkBean(relaxed = true)
@@ -205,5 +215,26 @@ class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
         val unikeUtbetalinger = allUtbetalinger.filter { it.referanse != "utbetalt-ref-1" }
         assertThat(unikeUtbetalinger).hasSize(3)
         assertThat(unikeUtbetalinger).allMatch { it.tilknyttedeSoknader.size == 1 }
+    }
+
+    @Test
+    suspend fun `Bulk-innehenting skal deles opp i chunks`() {
+
+        coEvery { fiksService.getAllInnsynsfiler(any()) } returns emptyMap()
+
+        innsynService.hentJsonDigisosSokerBulk(createDigisosSaker(504))
+
+        coVerify(exactly = 21) { fiksService.getAllInnsynsfiler(any()) }
+    }
+
+    private fun createDigisosSaker(n: Int): List<DigisosSak> {
+        return buildList {
+            for(i in 1..n) {
+                sosialhjelpJsonMapper.readValue(ok_digisossak_response, DigisosSak::class.java)
+                    .copy(fiksDigisosId = UUID.randomUUID().toString(), sokerFnr = i.toString())
+                    .also { add(it) }
+            }
+        }
+            .toList()
     }
 }

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.Test
 import org.springframework.test.web.reactive.server.expectBodyList
 
 class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
-
     @MockkSpyBean
     private lateinit var fiksService: FiksService
 

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
@@ -10,7 +10,6 @@ import no.nav.sosialhjelp.api.fiks.KommuneInfo
 import no.nav.sosialhjelp.innsyn.digisosapi.FiksService
 import no.nav.sosialhjelp.innsyn.digisossak.utbetalinger2.UtbetalingDto
 import no.nav.sosialhjelp.innsyn.domain.UtbetalingsStatus
-import no.nav.sosialhjelp.innsyn.event.InnsynService
 import no.nav.sosialhjelp.innsyn.kommuneinfo.KommuneInfoClient
 import no.nav.sosialhjelp.innsyn.responses.ok_digisossak_response
 import no.nav.sosialhjelp.innsyn.responses.ok_digisossak_response2
@@ -18,12 +17,9 @@ import no.nav.sosialhjelp.innsyn.utils.sosialhjelpJsonMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
 
 class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
-    @Autowired
-    private lateinit var innsynService: InnsynService
 
     @MockkSpyBean
     private lateinit var fiksService: FiksService

--- a/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/sosialhjelp/innsyn/integrasjonstest/UtbetalingerIntegrasjonsTest.kt
@@ -23,9 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.reactive.server.expectBodyList
 import java.util.UUID
 
-class UtbetalingerIntegrasjonsTest(
-) : AbstractIntegrationTest() {
-
+class UtbetalingerIntegrasjonsTest : AbstractIntegrationTest() {
     @Autowired
     private lateinit var innsynService: InnsynService
 
@@ -219,7 +217,6 @@ class UtbetalingerIntegrasjonsTest(
 
     @Test
     suspend fun `Bulk-innehenting skal deles opp i chunks`() {
-
         coEvery { fiksService.getAllInnsynsfiler(any()) } returns emptyMap()
 
         innsynService.hentJsonDigisosSokerBulk(createDigisosSaker(504))
@@ -227,14 +224,13 @@ class UtbetalingerIntegrasjonsTest(
         coVerify(exactly = 21) { fiksService.getAllInnsynsfiler(any()) }
     }
 
-    private fun createDigisosSaker(n: Int): List<DigisosSak> {
-        return buildList {
-            for(i in 1..n) {
-                sosialhjelpJsonMapper.readValue(ok_digisossak_response, DigisosSak::class.java)
+    private fun createDigisosSaker(n: Int): List<DigisosSak> =
+        buildList {
+            for (i in 1..n) {
+                sosialhjelpJsonMapper
+                    .readValue(ok_digisossak_response, DigisosSak::class.java)
                     .copy(fiksDigisosId = UUID.randomUUID().toString(), sokerFnr = i.toString())
                     .also { add(it) }
             }
-        }
-            .toList()
-    }
+        }.toList()
 }


### PR DESCRIPTION
Det kan potensielt være mange søknader for en person, og requestens levetid ved å hente alle innsynsfiler er ganske høy til tider. Ved å batche opp dette vil det senke levetiden pr. request og data-.overføring pr. request vil være mindre.